### PR TITLE
Create the specified prefix directory automatically

### DIFF
--- a/src/q4wine-gui/prefixsettings.cpp
+++ b/src/q4wine-gui/prefixsettings.cpp
@@ -199,9 +199,15 @@ void PrefixSettings::cmdOk_Click(){
 
     if (this->addNew){
 
-        if (QDir(path).exists()){
+        QDir directory(path);
+        if (directory.exists()){
             if(QMessageBox::warning(this, tr("Warning"), tr("Directory \"%1\" already exists. Do you wish to use it anyway?").arg(path), QMessageBox::Yes, QMessageBox::No)==QMessageBox::No)
                 return;
+        } else {
+            if (!directory.mkpath(".")) {
+                QMessageBox::critical(this, tr("Error"), tr("The directory \"%1\" could not be created.").arg(path), QMessageBox::Ok);
+                return;
+            }
         }
 
         if (!db_prefix.addPrefix(txtPrefixName->text(),  txtPrefixPath->text(), txtWineBin->text(), txtWineServerBin->text(), txtWineLoaderBin->text(), txtWineLibs->text(), txtMountPoint->text(), comboArchList->currentText(), this->comboWinDrive->currentText(), this->txtRunString->text()))


### PR DESCRIPTION
Although WINE will create the prefix directory by itself if that
path's parent exists, it will not do so if the prefix is more than
a level deep in uncreated directories.

For example, if the user is creating a new prefix in ~/wine/application
and ~/wine does not exist, WINE will not create the path and any
attempts to start applications with that prefix will fail.
