### PR TITLE
Some proxy-related fixes in Winetricks plugin

### DIFF
--- a/src/plugins/winetricks.cpp
+++ b/src/plugins/winetricks.cpp
@@ -189,15 +189,15 @@ void winetricks::downloadwinetricks () {
         }
     }
 
-    QString proxy_host = CoreLib->getSetting("network", "host", false).toString();
-    if (!proxy_host.isEmpty()){
-        args.append("env");
-        args.append(QString("https_proxy=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
-    }
-
     QString arg;
     arg.append(CoreLib->getWhichOut("sh"));
     arg.append(" -c \"");
+
+    QString proxy_host = CoreLib->getSetting("network", "host", false).toString();
+    if (!proxy_host.isEmpty()){
+        arg.append(QString("env https_proxy=http://%1:%2 ").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
+    }
+
     arg.append(CoreLib->getWhichOut("wget"));
     arg.append(" https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks -O ");
     arg.append(this->winetricks_bin);

--- a/src/plugins/winetricks.cpp
+++ b/src/plugins/winetricks.cpp
@@ -91,9 +91,9 @@ void winetricks::run_winetricks(QString item){
         sh_args.append("env");
 
         if (!proxy_host.isEmpty()){
-            sh_args.append(QString("HTTP_PROXY=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
-            sh_args.append(QString("HTTPS_PROXY=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
-            sh_args.append(QString("FTP_PROXY=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
+            sh_args.append(QString("http_proxy=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
+            sh_args.append(QString("https_proxy=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
+            sh_args.append(QString("ftp_proxy=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
         }
 
         QHash<QString, QString> prefix_info = db_prefix.getByName(this->prefix_name);
@@ -192,8 +192,7 @@ void winetricks::downloadwinetricks () {
     QString proxy_host = CoreLib->getSetting("network", "host", false).toString();
     if (!proxy_host.isEmpty()){
         args.append("env");
-        args.append(QString("HTTP_PROXY=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
-        args.append(QString("FTP_PROXY=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
+        args.append(QString("https_proxy=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
     }
 
     QString arg;

--- a/src/plugins/winetricks.cpp
+++ b/src/plugins/winetricks.cpp
@@ -91,9 +91,15 @@ void winetricks::run_winetricks(QString item){
         sh_args.append("env");
 
         if (!proxy_host.isEmpty()){
-            sh_args.append(QString("http_proxy=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
-            sh_args.append(QString("https_proxy=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
-            sh_args.append(QString("ftp_proxy=http://%1:%2").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
+            QString proxy_auth = CoreLib->getSetting("network", "user", false).toString();
+            if (!proxy_auth.isEmpty()){
+                QString proxy_pass = CoreLib->getSetting("network", "pass", false).toString();
+                proxy_auth.append(QString(":%1@").arg(proxy_pass));
+            }
+            QString proxy_var = QString("http://%1%2:%3").arg(proxy_auth).arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString());
+            sh_args.append(QString("http_proxy='%1'").arg(proxy_var));
+            sh_args.append(QString("https_proxy='%1'").arg(proxy_var));
+            sh_args.append(QString("ftp_proxy='%1'").arg(proxy_var));
         }
 
         QHash<QString, QString> prefix_info = db_prefix.getByName(this->prefix_name);
@@ -195,7 +201,13 @@ void winetricks::downloadwinetricks () {
 
     QString proxy_host = CoreLib->getSetting("network", "host", false).toString();
     if (!proxy_host.isEmpty()){
-        arg.append(QString("env https_proxy=http://%1:%2 ").arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString()));
+        QString proxy_auth = CoreLib->getSetting("network", "user", false).toString();
+        if (!proxy_auth.isEmpty()){
+            QString proxy_pass = CoreLib->getSetting("network", "pass", false).toString();
+            proxy_auth.append(QString(":%1@").arg(proxy_pass));
+        }
+        QString proxy_var = QString("http://%1%2:%3").arg(proxy_auth).arg(proxy_host).arg(CoreLib->getSetting("network", "port", false).toString());
+        arg.append(QString("env https_proxy='%1' ").arg(proxy_var));
     }
 
     arg.append(CoreLib->getWhichOut("wget"));


### PR DESCRIPTION
* Correct proxy-related environment variables in Winetricks plugin
    * Wget uses lowercase environment variables (e.g. http_proxy)
    * When Wget downloads Winetricks (HTTPS URL), https_proxy is used
* Use env command in the command line to download Winetricks
    * xterm does not start if proxy host is set
* Support proxy username/password in Winetricks plugin