### PR TITLE
Use QString::section() to parse Winetricks output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -220,3 +220,9 @@ Testing, bug reports
 mail: andrey.aleksandrovich@googlemail.com
 Kharkov, Ukraine
  
+Masanori Kakura (kakurasan)
+Bug reports, testing, some fixes, feature requests
+mail: kakurasan@gmail.com
+web: https://kakurasan.blogspot.com/
+Japan
+ 

--- a/src/plugins/winetricks.cpp
+++ b/src/plugins/winetricks.cpp
@@ -293,7 +293,7 @@ bool winetricks::parse() {
             foreach (QString item, this->get_stdout_lines(pargs)){
                 if ((item.isEmpty()) or (item.startsWith("Using winetricks")))
                     continue;
-                db_sysconfig.add_item(item.left(24).trimmed(), "application-x-ms-dos-executable", item.mid(24).trimmed(), subtype, D_PROVIDER_WINETRICKS);
+                db_sysconfig.add_item(item.section(' ', 0, 0), "application-x-ms-dos-executable", item.section(' ', 1, -1, QString::SectionSkipEmpty), subtype, D_PROVIDER_WINETRICKS);
             }
         }
     }

--- a/src/q4wine-gui/authors.h
+++ b/src/q4wine-gui/authors.h
@@ -644,5 +644,23 @@
         "<p style='margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;'>" \
 	    " " \
 	"</p>" \
+        "<p style='margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;'>" \
+	    "Masanori Kakura (kakurasan)" \
+	"</p>" \
+        "<p style='margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;'>" \
+	    "Bug reports, testing, some fixes, feature requests" \
+	"</p>" \
+        "<p style='margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;'>" \
+	    "<span style='color:#6495ed;'>E-Mail</span>: <a href='mailto:kakurasan@gmail.com' style='text-decoration: none; color:#5f9ea0;'>kakurasan@gmail.com</a>" \
+	"</p>" \
+        "<p style='margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;'>" \
+	    "<span style='color:#6495ed;'>Web</span>: <a href='https://kakurasan.blogspot.com/' style='color:#5f9ea0;'>https://kakurasan.blogspot.com/</a>" \
+	"</p>" \
+        "<p style='margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;'>" \
+	    "Japan" \
+	"</p>" \
+        "<p style='margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;'>" \
+	    " " \
+	"</p>" \
      "</body>" \
 "<html>"

--- a/src/q4wine-gui/authors.yaml
+++ b/src/q4wine-gui/authors.yaml
@@ -258,3 +258,10 @@ thanks:
           info: Testing, bug reports
           mail: andrey.aleksandrovich@googlemail.com
           location: Kharkov, Ukraine
+
+        - name: Masanori Kakura
+          nick: kakurasan
+          info: Bug reports, testing, some fixes, feature requests
+          mail: kakurasan@gmail.com
+          web: https://kakurasan.blogspot.com/
+          location: Japan


### PR DESCRIPTION
![q4wine-1 3 1-winetricks-strictdrawordering](https://cloud.githubusercontent.com/assets/10556453/17700554/41d9e548-6401-11e6-95f4-6af071ec1259.png)

"strictdrawordering=disabled" and "strictdrawordering=enabled" (over 24 chars) are broken.
This commit fixes the issue.