### PR TITLE
Fix parsing bug

### DIFF
--- a/src/core/registry.cpp
+++ b/src/core/registry.cpp
@@ -213,6 +213,8 @@ QStringList Registry::readExcludedKeys(const QString sysfile, const QString path
 		QByteArray line = file.readLine();
 
 		if ((readFlag) && (!line.trimmed().isEmpty())){
+			if (line.startsWith("#time"))
+				continue;
 			QList<QByteArray> key = line.trimmed().split('=');
 			int index = keys.indexOf(key.at(0));
 			if (index==-1){


### PR DESCRIPTION
When changing fake drive settings, the registry parser detected `#time=1d2cf273373c6e0` as DirectInput controller, which isn't correct controller setting and it disallowed saving the fake drive settings until removed. 
This should make it not happen