### PR TITLE
winetricks: Fix regexp for verb names that are used for setting OS version

### DIFF
--- a/src/plugins/winetricks.cpp
+++ b/src/plugins/winetricks.cpp
@@ -62,7 +62,7 @@ QStringList winetricks::get_installed() {
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         return installed_verbs;
     } else {
-        QRegExp winver_regexp("^nt40|vista|win([0-9][0-9k]?[0-9]?|xp|ver=)$");
+        QRegExp winver_regexp("^(nt40|vista|win([0-9][0-9k]?[0-9]?|xp|ver=))$");
         QTextStream textinputstream(&file);
         while (!textinputstream.atEnd()) {
             QString l = textinputstream.readLine();


### PR DESCRIPTION
Sorry, I found an issue in commit d17c65c.

I wrote a small program to test the regexp `^nt40|vista|win([0-9][0-9k]?[0-9]?|xp|ver=)$` and found that `(` and `)` are needed between `^` and `$`.

```cxx
#include <QDebug>
#include <cstdlib>

int
main()
{
    QDebug d(QtMsgType::QtDebugMsg);
    d.nospace();

    int errors = 0;

    // Bad regexp
    QRegExp winver_regexp("^nt40|vista|win([0-9][0-9k]?[0-9]?|xp|ver=)$");
    // Good regexp
//    QRegExp winver_regexp("^(nt40|vista|win([0-9][0-9k]?[0-9]?|xp|ver=))$");

    QString winver_names[] =
        {"nt40", "vista", "win2k", "win2k3", "win2k8", "win31", "win7", "win8",
         "win81", "win10", "win95", "win98", "winver=", "winxp", nullptr};
    // "winamp", "windowscodecs", "winhttp", and "wininet" are real verb names
    QString non_winver_names[] =
        {"mywinver=", "nt40test", "oldwinxp", "vistaver=", "vistawin", "winamp",
         "windowscodecs", "winhttp", "wininet", "winnt40", "winxp2k1", nullptr};

    d << "----- OS version verbs -----\n";
    for (int i = 0; winver_names[i] != nullptr; i++) {
        if (winver_regexp.indexIn(winver_names[i]) != -1) {
            d << "[OK] " << winver_names[i] << " : matched\n";
        } else {
            d << "[ERROR] " << winver_names[i] << " : not matched\n";
            errors++;
        }
    }

    d << "----- not OS version verbs -----\n";
    for (int i = 0; non_winver_names[i] != nullptr; i++) {
        if (winver_regexp.indexIn(non_winver_names[i]) == -1) {
            d << "[OK] " << non_winver_names[i] << " : not matched\n";
        } else {
            d << "[ERROR] " << non_winver_names[i] << " : matched\n";
            errors++;
        }
    }

    d << "----- Errors: " << errors << " -----";

    return errors ? EXIT_FAILURE : EXIT_SUCCESS;
}
```

The output is:
```
----- OS version verbs -----
[OK] "nt40" : matched
...
[OK] "winxp" : matched
----- not OS version verbs -----
[ERROR] "mywinver=" : matched
[ERROR] "nt40test" : matched
[ERROR] "oldwinxp" : matched
[ERROR] "vistaver=" : matched
[ERROR] "vistawin" : matched
[OK] "winamp" : not matched
...
----- Errors: 5 -----
```

The new regexp `^(nt40|vista|win([0-9][0-9k]?[0-9]?|xp|ver=))$` works as expected `(Errors: 0)`.

Note: Winetricks has some verbs that start with "win" and are not related to OS version: `winamp`, `windowscodecs`, `winhttp`, and `wininet`. So we cannot use a pattern like `^(nt40|vista|win.+)$`.