### PR TITLE
Update q4wine_de.ts

### DIFF
--- a/src/l10n/q4wine_de.ts
+++ b/src/l10n/q4wine_de.ts
@@ -83,7 +83,7 @@
         <location line="+16"/>
         <location line="+181"/>
         <source>Status: Connecting to %1</source>
-        <translation>Status: Verbindund mit %1 wird hergestellt</translation>
+        <translation>Status: Verbindung mit %1 wird hergestellt</translation>
     </message>
     <message>
         <location line="-100"/>


### PR DESCRIPTION
Fixed typo -> https://www.duden.de/rechtschreibung/Verbindung (correct version)