### PR TITLE
Minor bug fixes

### DIFF
--- a/src/plugins/winetricks.cpp
+++ b/src/plugins/winetricks.cpp
@@ -134,7 +134,8 @@ void winetricks::run_winetricks(const QString &item){
         }
     }
 
-    if (console_bin.split("/").last() == "konsole"){
+    QString console_last = console_bin.split("/").last();
+    if ((console_last == "konsole") || (console_last == "st") || (console_last == "stterm")){
         args.append("/bin/sh");
         args.append("-c");
     }
@@ -211,6 +212,7 @@ QStringList winetricks::get_command(const QString &item){
     sh_args.append(CoreLib->getWhichOut("sh"));
     sh_args.append("-c");
     sh_args.append(QString("\"%1 --no-isolate %2\"").arg(this->winetricks_bin).arg(item));
+    sh_args.append("; echo '== Press Enter to Close =='; read n");
     return sh_args;
 }
 

--- a/src/q4wine-gui/iconsettings.cpp
+++ b/src/q4wine-gui/iconsettings.cpp
@@ -457,22 +457,18 @@ void IconSettings::cmdGetIcon_Click(){
             args << "-x";
             args << "-t" << "14";
 
-            QString tmpDir="";
-            QStringList list1 = fileName.split("/");
-
-            tmpDir.append(QDir::homePath());
-            tmpDir.append("/.config/");
+            QString tmpDir = QDir::tempPath();
+            tmpDir.append("/");
             tmpDir.append(APP_SHORT_NAME);
-            tmpDir.append("/tmp/");
-            tmpDir.append(list1.last());
+            tmpDir.append("-");
+            tmpDir.append(fileName.split("/").last());
 
             QDir tmp(tmpDir);
-            tmp.setFilter(QDir::Files | QDir::Hidden | QDir::NoSymLinks);
-            QFileInfoList list = tmp.entryInfoList();
+            QFileInfoList allFilesList = tmp.entryInfoList(QDir::Files | QDir::Hidden | QDir::NoSymLinks);
 
             if (tmp.exists(tmpDir)){
-                for (int i = 0; i < list.size(); ++i) {
-                    QFileInfo fileInfo = list.at(i);
+                for (int i = 0; i < allFilesList.size(); ++i) {
+                    QFileInfo fileInfo = allFilesList.at(i);
                     if (!tmp.remove(fileInfo.filePath()))
                         qDebug()<<"[EE] - Cannot delete files at: "<<fileInfo.filePath();
                 }
@@ -492,16 +488,17 @@ void IconSettings::cmdGetIcon_Click(){
                 args.clear();
                 args << "-x";
 
-                QDir ico_dir(tmpDir);
                 // Updating file index
-                list = ico_dir.entryInfoList();
+                QStringList nameFilters;
+                nameFilters << "*.ico";
+
+                QFileInfoList icoFilesList = tmp.entryInfoList(nameFilters, QDir::Files | QDir::Hidden | QDir::NoSymLinks);
 
                 //Creating file list for converting
-                for (int i = 0; i < list.size(); ++i) {
-                    QFileInfo fileInfo = list.at(i);
+                for (int i = 0; i < icoFilesList.size(); ++i) {
+                    QFileInfo fileInfo = icoFilesList.at(i);
                     qDebug() << fileInfo.fileName();
-                    if (fileInfo.fileName().right(3)=="ico")
-                        args << fileInfo.filePath();
+                    args << fileInfo.filePath();
                 }
 
                 args << "-o" << QString("%1/").arg(tmpDir);
@@ -536,11 +533,11 @@ void IconSettings::cmdGetIcon_Click(){
             }
 
             //Clearing temp files
-            list = tmp.entryInfoList();
+            allFilesList = tmp.entryInfoList(QDir::Files | QDir::Hidden | QDir::NoSymLinks);
 
                 //Creating file list for converting
-            for (int i = 0; i < list.size(); ++i) {
-                QFileInfo fileInfo = list.at(i);
+            for (int i = 0; i < allFilesList.size(); ++i) {
+                QFileInfo fileInfo = allFilesList.at(i);
                     if (!QFile::remove(fileInfo.filePath()))
                         qDebug()<<"[EE] - Cannot delete files at: "<<fileInfo.filePath();
             }

--- a/src/q4wine-lib/q4wine-lib.cpp
+++ b/src/q4wine-lib/q4wine-lib.cpp
@@ -743,8 +743,8 @@ QString corelib::getMountedImages(QString cdrom_mount) const{
     QFile file(filename);
     if (file.open(QIODevice::ReadOnly | QIODevice::Text)){
         QTextStream in(&file);
-        while (!in.atEnd()) {
-            QString line = in.readLine();
+        QString line;
+        while (in.readLineInto(&line)) {
 #ifdef DEBUG
             qDebug()<<"corelib::/etc/mtab:line"<<line;
 #endif
@@ -759,8 +759,8 @@ QString corelib::getMountedImages(QString cdrom_mount) const{
                     QFile file(filename);
                     if (file.open(QIODevice::ReadOnly | QIODevice::Text)){
                         QTextStream in(&file);
-                        while (!in.atEnd()) {
-                            QString line = in.readLine();
+                        QString line;
+                        while (in.readLineInto(&line)) {
 #ifdef DEBUG
                             qDebug()<<"corelib::getMountedImages:line"<<line;
 #endif


### PR DESCRIPTION
I migrated over to q4wine from PlayOnLinux and noticed a few things that were not working properly, so I attempted to fix them. For the terminal fix, an alternative might be to always append /bin/sh -c as the worst case scenario would be an extra sh session (I think). The biggest bug I found was the problem parsing mtab. I even checked another project (udisks I think) and their code was the same as yours and it did not work.

    Fixed a bug where /etc/mtab was not being read and resulted in being unable to unmount iso images.
    Fixed a bug where the temporary director for generating icons wasn't being deleted. Refactored this to use QDir::tempPath().
    Added workaround for st terminal, similar to konsole.
    Added a feature to keep the terminal open when running winetricks so users can see the output.
