### PR TITLE
FreeBSD\clang error: use of undeclared identifier 'LC_*' (again)

### DIFF
--- a/src/q4wine-gui/process.h
+++ b/src/q4wine-gui/process.h
@@ -31,6 +31,7 @@
 #include <QLibrary>
 #include <QTextCodec>
 #include <QTextStream>
+#include <locale.h>
 
 #ifdef DEBUG
 #include <QDebug>


### PR DESCRIPTION
As done in 0b91214835d5569e10e5818875b340f6f850d314.