### PR TITLE
[BUG-178] XDG Base Directory Specification support (WIP)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 1.3.13
   - Prefix Import feature is not working as expected [BUG-156];
   - Misspelled Color Theme Settings [BUG-155];
   - CMake warning [BUG-158];
+  - XDG Base Directory Specification support [BUG-178];
 
 Version 1.3.12
  Updated:

--- a/src/core/database/db.cpp
+++ b/src/core/database/db.cpp
@@ -33,15 +33,15 @@ DataBase::DataBase(QObject * parent): QObject(parent){
     }
 
     QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
-
+    QString db_path = QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QDir::separator() + APP_SHORT_NAME + QDir::separator() + "db" + QDir::separator() + "generic.dat");
 #ifdef DEBUG
-    qDebug()<<"[ii] Loading database file: "<<QString("%1/.config/%2/db/generic.dat").arg(QDir::homePath()).arg(APP_SHORT_NAME);
+    qDebug() << "[ii] Loading database file: " << db_path;
 #endif
 
-    db.setDatabaseName(QString("%1/.config/%2/db/generic.dat").arg(QDir::homePath()).arg(APP_SHORT_NAME));
+    db.setDatabaseName(db_path);
 
     if (!db.open()){
-        QErr<<"[EE] "<<"Critical error"<<" : "<<QString("Cannot open database file: %1/.config/%2/db/generic.dat ; Error is: %3").arg(QDir::homePath()).arg(APP_SHORT_NAME).arg(db.lastError().text())<<endl;
+        QErr<<"[EE] "<<"Critical error"<<" : "<<QString("Cannot open database file: %1 ; Error is: %2").arg(db_path).arg(db.lastError().text())<<endl;
         return;
     }
 

--- a/src/core/database/db.h
+++ b/src/core/database/db.h
@@ -24,6 +24,7 @@
 #ifndef DB_H
 #define DB_H
 
+#include <QStandardPaths>
 #include <QSqlDatabase>
 #include <QSqlRecord>
 #include <QStringList>

--- a/src/core/httpcore.cpp
+++ b/src/core/httpcore.cpp
@@ -94,8 +94,7 @@ void HttpCore::getAppDBXMLPage(QString host, short int port, QString page)
 }
 
 bool HttpCore::getCacheFile(QString page){
-    QString cache_file = QDir::homePath();
-    cache_file.append("/.config/");
+    QString cache_file = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
     cache_file.append(APP_SHORT_NAME);
     cache_file.append("/tmp/cache/");
     cache_file.append(QCryptographicHash::hash(page.toUtf8().constData(), QCryptographicHash::Md4).toHex());
@@ -117,10 +116,7 @@ bool HttpCore::getCacheFile(QString page){
 }
 
 QString HttpCore::getXMLReply(){
-    QString cache_file = QDir::homePath();
-    cache_file.append("/.config/");
-    cache_file.append(APP_SHORT_NAME);
-    cache_file.append("/tmp/cache/");
+    QString cache_file = QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QDir::separator() + APP_SHORT_NAME + QDir::separator() + "tmp" + QDir::separator() + "cache" + QDir::separator());
     cache_file.append(QCryptographicHash::hash(this->page.toUtf8().constData(), QCryptographicHash::Md4).toHex());
 
     QFile file(cache_file);

--- a/src/core/httpcore.h
+++ b/src/core/httpcore.h
@@ -28,7 +28,8 @@
 #include <QNetworkReply>
 #include <QNetworkProxy>
 #include <QMessageBox>
- #include <QCryptographicHash>
+#include <QStandardPaths>
+#include <QCryptographicHash>
 
 #ifdef DEBUG
 #include <QDebug>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include <QTranslator>
 #include <QMessageBox>
 #include <QTextStream>
+#include <QStandardPaths>
 
 #ifdef DEBUG
 
@@ -141,7 +142,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (!CoreLib->checkDirs(QString("%1/.config/%2").arg(QDir::homePath()).arg(APP_SHORT_NAME))){
+    if (!CoreLib->checkDirs(QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QDir::separator() + APP_SHORT_NAME))){
         return -1;
     }
 

--- a/src/plugins/sysmenu.cpp
+++ b/src/plugins/sysmenu.cpp
@@ -40,7 +40,7 @@ system_menu::system_menu()
 
     base_directory = QString("%1/.local/share/desktop-directories").arg(home_path);
     base_icon = QString("%1/.local/share/applications").arg(home_path);
-    base_menu = QString("%1/.config/menus/applications-merged/%2.menu").arg(home_path).arg(APP_SHORT_NAME);
+    base_menu = QString("%1/menus/applications-merged/%2.menu").arg(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)).arg(APP_SHORT_NAME);
 }
 
 bool system_menu::add_dom_icons(QDomDocument &menu_xml, QDomElement &root, const QString &prefix_name, const QString &dir_name, const QStringList &iconsList){

--- a/src/plugins/sysmenu.h
+++ b/src/plugins/sysmenu.h
@@ -29,7 +29,7 @@
 #include <QDomDocument>
 #include <QDomElement>
 #include <QDomText>
-
+#include <QStandardPaths>
 #include <QStringList>
 #include <QTextStream>
 #include <QString>

--- a/src/plugins/winetricks.cpp
+++ b/src/plugins/winetricks.cpp
@@ -37,10 +37,12 @@ winetricks::winetricks(const QString &prefixName) : QWidget()
     CoreLibClassPointer = reinterpret_cast<CoreLibPrototype*>(libq4wine.resolve("createCoreLib"));
     CoreLib.reset(static_cast<corelib *>(CoreLibClassPointer(true)));
 
-    this->winetricks_bin = QDir::homePath();
-    this->winetricks_bin.append("/.config/");
-    this->winetricks_bin.append(APP_SHORT_NAME);
-    this->winetricks_bin.append("/winetricks");
+    this->winetricks_bin = QDir::cleanPath(
+        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+        QDir::separator() +
+        APP_SHORT_NAME +
+        QDir::separator() +
+        "winetricks");
 
     if (!check_script(false)){
         this->winetricks_bin = CoreLib->getWhichOut("winetricks", false);
@@ -220,10 +222,12 @@ void winetricks::downloadwinetricks () {
     /*
      * Downloading winetricks and installing it
      */
-    this->winetricks_bin = QDir::homePath();
-    this->winetricks_bin.append("/.config/");
-    this->winetricks_bin.append(APP_SHORT_NAME);
-    this->winetricks_bin.append("/winetricks");
+    this->winetricks_bin = QDir::cleanPath(
+        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+        QDir::separator() +
+        APP_SHORT_NAME +
+        QDir::separator() +
+        "winetricks");
 
     QFile file(this->winetricks_bin);
 

--- a/src/plugins/winetricks.h
+++ b/src/plugins/winetricks.h
@@ -28,6 +28,7 @@
 #include <QProcess>
 #include <QMessageBox>
 #include <QLibrary>
+#include <QStandardPaths>
 #include <QProgressDialog>
 #include <QTextStream>
 #include <QFile>

--- a/src/q4wine-gui/iconsettings.cpp
+++ b/src/q4wine-gui/iconsettings.cpp
@@ -637,8 +637,12 @@ void IconSettings::cmdGetPreRun_Click(){
     QString fileName;
     QString searchPath = "";
     if (txtPreRun->text().isEmpty()) {
-        searchPath = QDir::homePath();
-        searchPath.append("/.config/q4wine/scripts");
+        searchPath = QDir::cleanPath(
+            QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+            QDir::separator() +
+            APP_SHORT_NAME +
+            QDir::separator() +
+            "scripts");
     } else {
         searchPath = QFileInfo(txtPreRun->text()).absolutePath();
     }
@@ -664,8 +668,12 @@ void IconSettings::cmdGetPostRun_Click(){
     QString fileName;
     QString searchPath = "";
     if (txtPostRun->text().isEmpty()) {
-        searchPath = QDir::homePath();
-        searchPath.append("/.config/q4wine/scripts");
+        searchPath = QDir::cleanPath(
+            QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+            QDir::separator() +
+            APP_SHORT_NAME +
+            QDir::separator() +
+            "scripts");
     } else {
         searchPath = QFileInfo(txtPostRun->text()).absolutePath();
     }

--- a/src/q4wine-gui/iconsettings.h
+++ b/src/q4wine-gui/iconsettings.h
@@ -42,6 +42,7 @@
 #include <QResizeEvent>
 #include <QKeyEvent>
 #include <QHeaderView>
+#include <QStandardPaths>
 #include <QTableWidgetItem>
 #include <QTemporaryDir>
 

--- a/src/q4wine-gui/iconsview.cpp
+++ b/src/q4wine-gui/iconsview.cpp
@@ -91,12 +91,14 @@ void IconsView::cmdOk_Click(){
 		sourceFile.append(lstIcons->currentItem()->text());
 
 		if (cbDefaultExport->checkState()==Qt::Checked){
-		saveFile.clear();
-		saveFile.append(QDir::homePath());
-		saveFile.append("/.config/");
-		saveFile.append(APP_SHORT_NAME);
-		saveFile.append("/icons/");
-		saveFile.append(lstIcons->currentItem()->text());
+        saveFile = QDir::cleanPath(
+            QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+            QDir::separator() +
+            APP_SHORT_NAME +
+            QDir::separator() +
+            "icons" +
+            QDir::separator() +
+            lstIcons->currentItem()->text());
 
 		saveFileName=lstIcons->currentItem()->text();
 
@@ -116,24 +118,29 @@ void IconsView::cmdOk_Click(){
 																		tr("Replace existing file or rename current one?"), QLineEdit::Normal,
 																	saveFileName , &ok);
 						if ((!saveFileName.isEmpty()) && (ok)){
-							saveFile.clear();
-							saveFile.append(QDir::homePath());
-							saveFile.append("/.config/");
-							saveFile.append(APP_SHORT_NAME);
-							saveFile.append("/icons/");
-							saveFile.append(saveFileName);
+                            saveFile = QDir::cleanPath(
+                                QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+                                QDir::separator() +
+                                APP_SHORT_NAME +
+                                QDir::separator() +
+                                "icons" +
+                                QDir::separator() +
+                                saveFileName);
+
 						} else {
 							reject();
 							return;
 						}
 					break;
 					case 1:
-						saveFile.clear();
-						saveFile.append(QDir::homePath());
-						saveFile.append("/.config/");
-						saveFile.append(APP_SHORT_NAME);
-						saveFile.append("/icons/");
-						saveFile.append(saveFileName);
+                        saveFile = QDir::cleanPath(
+                            QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+                            QDir::separator() +
+                            APP_SHORT_NAME +
+                            QDir::separator() +
+                            "icons" +
+                            QDir::separator() +
+                            saveFileName);
 						selectedFile=saveFile;
 						accept();
 						return;
@@ -151,11 +158,12 @@ void IconsView::cmdOk_Click(){
 		}
 
 		} else {
-			saveFile.clear();
-			saveFile.append(QDir::homePath());
-			saveFile.append("/.config/");
-			saveFile.append(APP_SHORT_NAME);
-			saveFile.append("/icons/");
+            saveFile = QDir::cleanPath(
+                QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+                QDir::separator() +
+                APP_SHORT_NAME +
+                QDir::separator() +
+                "icons");
 
         QFileDialog::Options options;
 

--- a/src/q4wine-gui/iconsview.h
+++ b/src/q4wine-gui/iconsview.h
@@ -28,6 +28,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QInputDialog>
+#include <QStandardPaths>
 #include <QAbstractItemView>
 #include <QDialog>
 

--- a/src/q4wine-gui/mainwindow.cpp
+++ b/src/q4wine-gui/mainwindow.cpp
@@ -225,17 +225,19 @@ void MainWindow::setSearchFocus(){
 }
 
 void MainWindow::clearTmp(){
-    QString fileName = QDir::homePath();
-    fileName.append("/.config/");
-    fileName.append(APP_SHORT_NAME);
-    fileName.append("/tmp");
+    QString fileName = QDir::cleanPath(
+        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+        QDir::separator() +
+        APP_SHORT_NAME +
+        QDir::separator() +
+        "tmp");
 
     if (not CoreLib->removeDirectory(fileName)){
         qWarning()<<"[WW] Can't clear "<<fileName;
         return;
     }
 
-    if (!CoreLib->checkDirs(QString("%1/.config/%2").arg(QDir::homePath()).arg(APP_SHORT_NAME), QStringList() << "tmp" << "tmp/cache")){
+    if (!CoreLib->checkDirs(QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QDir::separator() + APP_SHORT_NAME), QStringList() << "tmp" << "tmp/cache")){
         return;
     }
 

--- a/src/q4wine-gui/mainwindow.h
+++ b/src/q4wine-gui/mainwindow.h
@@ -29,6 +29,7 @@
 #include <src/q4wine-gui/ui_MainWindow.h>
 
 //Qt includes
+#include <QStandardPaths>
 #include <QSystemTrayIcon>
 #include <QSplitter>
 #include <QLocalServer>

--- a/src/q4wine-gui/widgets/prefixcontrolwidget.cpp
+++ b/src/q4wine-gui/widgets/prefixcontrolwidget.cpp
@@ -289,11 +289,12 @@ void PrefixControlWidget::prefixImport_Click(){
         targetDir.append("/.wine/");
     }
 
-    QString openpath = QDir::homePath();
-    openpath.append("/.config/");
-    openpath.append(APP_SHORT_NAME);
-    openpath.append("/prefixes/");
-
+    QString openpath = QDir::cleanPath(
+        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+        QDir::separator() +
+        APP_SHORT_NAME +
+        QDir::separator() +
+        "prefixes");
     QFileDialog::Options options;
 
     if (CoreLib->getSetting("advanced", "useNativeFileDialog", false, 1)==0)
@@ -389,10 +390,13 @@ void PrefixControlWidget::prefixExport_Click(){
         prefixPath.append("/.wine/");
     }
 
-    QString savepath = QDir::homePath();
-    savepath.append("/.config/");
-    savepath.append(APP_SHORT_NAME);
-    savepath.append("/prefixes/");
+    QString savepath = QDir::cleanPath(
+        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+        QDir::separator() +
+        APP_SHORT_NAME +
+        QDir::separator() +
+        "prefixes");
+    savepath.append(QDir::separator());
     savepath.append(prefixName);
     savepath.append("-");
     savepath.append(QDate::currentDate().toString(Qt::ISODate));

--- a/src/q4wine-gui/widgets/prefixcontrolwidget.h
+++ b/src/q4wine-gui/widgets/prefixcontrolwidget.h
@@ -34,6 +34,7 @@
 #endif
 
 //Qt includes
+#include <QStandardPaths>
 #include <QSqlQueryModel>
 #include <QTableView>
 #include <QCheckBox>

--- a/src/q4wine-lib/q4wine-lib.cpp
+++ b/src/q4wine-lib/q4wine-lib.cpp
@@ -1102,10 +1102,12 @@ QString corelib::createDesktopFile(const QString &prefix_name, const QString &di
         fileName.append(dir_name);
         fileName.append("/");
     } else {
-        fileName = QDir::homePath();
-        fileName.append("/.config/");
-        fileName.append(APP_SHORT_NAME);
-        fileName.append("/tmp/");
+        fileName = QDir::cleanPath(
+            QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+            QDir::separator() +
+            APP_SHORT_NAME +
+            QDir::separator() +
+            "tmp");
     }
 
     fileName.append(result.value("name"));

--- a/src/q4wine-lib/q4wine-lib.h
+++ b/src/q4wine-lib/q4wine-lib.h
@@ -43,6 +43,7 @@
 #include <QRegExp>
 #include <QTextCodec>
 #include <QTextStream>
+#include <QStandardPaths>
 #include <QDesktopServices>
 #include <QUrl>
 #include <QTranslator>


### PR DESCRIPTION
Addresses #178

Scope of the changes:
* Use QStandardPaths Class instead of `${HOME}/.config/` hardcode;
* Use QStandardPaths Class instead of `${HOME}/.local/share/` hardcode;