### PR TITLE
[BUG-178] Unhardcode all XDG standard paths

### DIFF
--- a/src/core/database/db.cpp
+++ b/src/core/database/db.cpp
@@ -35,13 +35,13 @@ DataBase::DataBase(QObject * parent): QObject(parent){
     QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
 
 #ifdef DEBUG
-    qDebug()<<"[ii] Loading database file: "<<QString("%1/.config/%2/db/generic.dat").arg(QDir::homePath()).arg(APP_SHORT_NAME);
+    qDebug()<<"[ii] Loading database file: "<<QString("%1/db/generic.dat").arg(corelib::getAppConfigLocation());
 #endif
 
-    db.setDatabaseName(QString("%1/.config/%2/db/generic.dat").arg(QDir::homePath()).arg(APP_SHORT_NAME));
+    db.setDatabaseName(QString("%1/db/generic.dat").arg(corelib::getAppConfigLocation()));
 
     if (!db.open()){
-        QErr<<"[EE] "<<"Critical error"<<" : "<<QString("Cannot open database file: %1/.config/%2/db/generic.dat ; Error is: %3").arg(QDir::homePath()).arg(APP_SHORT_NAME).arg(db.lastError().text())<<endl;
+        QErr<<"[EE] "<<"Critical error"<<" : "<<QString("Cannot open database file: %1/db/generic.dat ; Error is: %3").arg(corelib::getAppConfigLocation()).arg(db.lastError().text())<<endl;
         return;
     }
 

--- a/src/core/database/db.h
+++ b/src/core/database/db.h
@@ -39,6 +39,7 @@
 
 #include "config.h"
 #include "core/database/versions.h"
+#include "q4wine-lib.h"
 
 /*!
  * \class DataBase

--- a/src/core/httpcore.cpp
+++ b/src/core/httpcore.cpp
@@ -94,10 +94,7 @@ void HttpCore::getAppDBXMLPage(QString host, short int port, QString page)
 }
 
 bool HttpCore::getCacheFile(QString page){
-    QString cache_file = QDir::homePath();
-    cache_file.append("/.config/");
-    cache_file.append(APP_SHORT_NAME);
-    cache_file.append("/tmp/cache/");
+    QString cache_file = corelib::getAppCacheLocation();
     cache_file.append(QCryptographicHash::hash(page.toUtf8().constData(), QCryptographicHash::Md4).toHex());
 
     QFile file(cache_file);
@@ -117,10 +114,7 @@ bool HttpCore::getCacheFile(QString page){
 }
 
 QString HttpCore::getXMLReply(){
-    QString cache_file = QDir::homePath();
-    cache_file.append("/.config/");
-    cache_file.append(APP_SHORT_NAME);
-    cache_file.append("/tmp/cache/");
+    QString cache_file = corelib::getAppCacheLocation();
     cache_file.append(QCryptographicHash::hash(this->page.toUtf8().constData(), QCryptographicHash::Md4).toHex());
 
     QFile file(cache_file);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,11 +141,11 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (!CoreLib->checkDirs(QString("%1/.config/%2").arg(QDir::homePath()).arg(APP_SHORT_NAME))){
+    if (!CoreLib->checkDirs(corelib::getAppConfigLocation())){
         return -1;
     }
 
-    if (!CoreLib->checkDirs(QDir::homePath(), QStringList() << ".local/share/wineprefixes")){
+    if (!CoreLib->checkDirs(corelib::getGenericDataLocation(), QStringList() << "wineprefixes")){
         return -1;
     }
 

--- a/src/plugins/sysmenu.cpp
+++ b/src/plugins/sysmenu.cpp
@@ -16,7 +16,6 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "sysmenu.h"
 
 system_menu::system_menu()
@@ -36,11 +35,9 @@ system_menu::system_menu()
     CoreLibClassPointer = reinterpret_cast<CoreLibPrototype*>(libq4wine.resolve("createCoreLib"));
     CoreLib.reset(static_cast<corelib *>(CoreLibClassPointer(true)));
 
-    QString home_path = QDir::homePath();
-
-    base_directory = QString("%1/.local/share/desktop-directories").arg(home_path);
-    base_icon = QString("%1/.local/share/applications").arg(home_path);
-    base_menu = QString("%1/.config/menus/applications-merged/%2.menu").arg(home_path).arg(APP_SHORT_NAME);
+    base_directory = QString("%1/desktop-directories").arg(corelib::getGenericDataLocation());
+    base_icon = QString("%1/applications").arg(corelib::getGenericDataLocation());
+    base_menu = QString("%1/menus/applications-merged/%2.menu").arg(corelib::getGenericConfigLocation()).arg(APP_SHORT_NAME);
 }
 
 bool system_menu::add_dom_icons(QDomDocument &menu_xml, QDomElement &root, const QString &prefix_name, const QString &dir_name, const QStringList &iconsList){

--- a/src/plugins/winetricks.cpp
+++ b/src/plugins/winetricks.cpp
@@ -37,9 +37,7 @@ winetricks::winetricks(const QString &prefixName) : QWidget()
     CoreLibClassPointer = reinterpret_cast<CoreLibPrototype*>(libq4wine.resolve("createCoreLib"));
     CoreLib.reset(static_cast<corelib *>(CoreLibClassPointer(true)));
 
-    this->winetricks_bin = QDir::homePath();
-    this->winetricks_bin.append("/.config/");
-    this->winetricks_bin.append(APP_SHORT_NAME);
+    this->winetricks_bin = corelib::getAppConfigLocation();
     this->winetricks_bin.append("/winetricks");
 
     if (!check_script(false)){
@@ -220,9 +218,7 @@ void winetricks::downloadwinetricks () {
     /*
      * Downloading winetricks and installing it
      */
-    this->winetricks_bin = QDir::homePath();
-    this->winetricks_bin.append("/.config/");
-    this->winetricks_bin.append(APP_SHORT_NAME);
+    this->winetricks_bin = corelib::getAppConfigLocation();
     this->winetricks_bin.append("/winetricks");
 
     QFile file(this->winetricks_bin);

--- a/src/q4wine-gui/iconsettings.cpp
+++ b/src/q4wine-gui/iconsettings.cpp
@@ -393,8 +393,8 @@ void IconSettings::cmdGetProgram_Click(){
 }
 
 void IconSettings::getProgramIcon(QString name){
-    QString local_path = QDir::homePath();
-    local_path.append("/.local/share/icons/");
+    QString local_path = corelib::getGenericDataLocation();
+    local_path.append("/icons/");
 
     QDir dir(local_path, QString("*_%1.*").arg(name));
     dir.setFilter(QDir::Files | QDir::Hidden | QDir::NoSymLinks);
@@ -637,8 +637,8 @@ void IconSettings::cmdGetPreRun_Click(){
     QString fileName;
     QString searchPath = "";
     if (txtPreRun->text().isEmpty()) {
-        searchPath = QDir::homePath();
-        searchPath.append("/.config/q4wine/scripts");
+        searchPath = corelib::getAppConfigLocation();
+        searchPath.append("/scripts");
     } else {
         searchPath = QFileInfo(txtPreRun->text()).absolutePath();
     }
@@ -664,8 +664,8 @@ void IconSettings::cmdGetPostRun_Click(){
     QString fileName;
     QString searchPath = "";
     if (txtPostRun->text().isEmpty()) {
-        searchPath = QDir::homePath();
-        searchPath.append("/.config/q4wine/scripts");
+        searchPath = corelib::getAppConfigLocation();
+        searchPath.append("/scripts");
     } else {
         searchPath = QFileInfo(txtPostRun->text()).absolutePath();
     }

--- a/src/q4wine-gui/iconsview.cpp
+++ b/src/q4wine-gui/iconsview.cpp
@@ -92,9 +92,7 @@ void IconsView::cmdOk_Click(){
 
 		if (cbDefaultExport->checkState()==Qt::Checked){
 		saveFile.clear();
-		saveFile.append(QDir::homePath());
-		saveFile.append("/.config/");
-		saveFile.append(APP_SHORT_NAME);
+		saveFile.append(corelib::getAppConfigLocation());
 		saveFile.append("/icons/");
 		saveFile.append(lstIcons->currentItem()->text());
 
@@ -117,9 +115,7 @@ void IconsView::cmdOk_Click(){
 																	saveFileName , &ok);
 						if ((!saveFileName.isEmpty()) && (ok)){
 							saveFile.clear();
-							saveFile.append(QDir::homePath());
-							saveFile.append("/.config/");
-							saveFile.append(APP_SHORT_NAME);
+							saveFile.append(corelib::getAppConfigLocation());
 							saveFile.append("/icons/");
 							saveFile.append(saveFileName);
 						} else {
@@ -129,9 +125,7 @@ void IconsView::cmdOk_Click(){
 					break;
 					case 1:
 						saveFile.clear();
-						saveFile.append(QDir::homePath());
-						saveFile.append("/.config/");
-						saveFile.append(APP_SHORT_NAME);
+						saveFile.append(corelib::getAppConfigLocation());
 						saveFile.append("/icons/");
 						saveFile.append(saveFileName);
 						selectedFile=saveFile;
@@ -152,9 +146,7 @@ void IconsView::cmdOk_Click(){
 
 		} else {
 			saveFile.clear();
-			saveFile.append(QDir::homePath());
-			saveFile.append("/.config/");
-			saveFile.append(APP_SHORT_NAME);
+			saveFile.append(corelib::getAppConfigLocation());
 			saveFile.append("/icons/");
 
         QFileDialog::Options options;

--- a/src/q4wine-gui/mainwindow.cpp
+++ b/src/q4wine-gui/mainwindow.cpp
@@ -42,7 +42,7 @@ MainWindow::MainWindow(const int startState, const QString &run_binary, QWidget 
         progress.exec();
     }
 
-    //  importIcons(QString("%1/.local/share/applications/wine/").arg(QDir::homePath()));
+    //  importIcons(QString("%1/applications/wine/").arg(corelib::getGenericDataLocation()));
 
     //exportProcess.close();
     // Base GUI setup
@@ -225,9 +225,7 @@ void MainWindow::setSearchFocus(){
 }
 
 void MainWindow::clearTmp(){
-    QString fileName = QDir::homePath();
-    fileName.append("/.config/");
-    fileName.append(APP_SHORT_NAME);
+    QString fileName = corelib::getAppConfigLocation();
     fileName.append("/tmp");
 
     if (not CoreLib->removeDirectory(fileName)){
@@ -235,7 +233,7 @@ void MainWindow::clearTmp(){
         return;
     }
 
-    if (!CoreLib->checkDirs(QString("%1/.config/%2").arg(QDir::homePath()).arg(APP_SHORT_NAME), QStringList() << "tmp" << "tmp/cache")){
+    if (!CoreLib->checkDirs(corelib::getAppConfigLocation(), QStringList() << "tmp" << "tmp/cache")){
         return;
     }
 

--- a/src/q4wine-gui/widgets/prefixcontrolwidget.cpp
+++ b/src/q4wine-gui/widgets/prefixcontrolwidget.cpp
@@ -289,9 +289,7 @@ void PrefixControlWidget::prefixImport_Click(){
         targetDir.append("/.wine/");
     }
 
-    QString openpath = QDir::homePath();
-    openpath.append("/.config/");
-    openpath.append(APP_SHORT_NAME);
+    QString openpath = corelib::getAppConfigLocation();
     openpath.append("/prefixes/");
 
     QFileDialog::Options options;
@@ -389,9 +387,7 @@ void PrefixControlWidget::prefixExport_Click(){
         prefixPath.append("/.wine/");
     }
 
-    QString savepath = QDir::homePath();
-    savepath.append("/.config/");
-    savepath.append(APP_SHORT_NAME);
+    QString savepath = corelib::getAppConfigLocation();
     savepath.append("/prefixes/");
     savepath.append(prefixName);
     savepath.append("-");

--- a/src/q4wine-lib/q4wine-lib.cpp
+++ b/src/q4wine-lib/q4wine-lib.cpp
@@ -27,6 +27,30 @@ corelib* createCoreLib(const bool GUI_MODE){
     return new corelib(GUI_MODE);
 }
 
+const QString corelib::getGenericConfigLocation() {
+    return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
+}
+
+const QString corelib::getAppConfigLocation() {
+    return QString("%1/%2").arg(getGenericConfigLocation()).arg(APP_SHORT_NAME);
+}
+
+const QString corelib::getGenericDataLocation() {
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+}
+
+const QString corelib::getAppDataLocation() {
+    return QString("%1/%2").arg(getGenericDataLocation()).arg(APP_SHORT_NAME);
+}
+
+const QString corelib::getGenericCacheLocation() {
+    return QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
+}
+
+const QString corelib::getAppCacheLocation() {
+    return QString("%1/%2").arg(getGenericCacheLocation()).arg(APP_SHORT_NAME);
+}
+
 QList<QStringList> corelib::getWineProcessList(const QString &prefix_name){
     QList<QStringList> proclist;
     QStringList procline;
@@ -381,8 +405,8 @@ void corelib::checkSettings(){
     }
 
     if (this->getSetting("advanced", "prefixDefaultPath", false).toString().isEmpty()){
-        QString path = QDir::homePath();
-        path.append("/.local/share/wineprefixes");
+        QString path = this->getGenericDataLocation();
+        path.append("/wineprefixes");
 
         QSettings settings(APP_SHORT_NAME, "default");
         settings.beginGroup("advanced");
@@ -1085,7 +1109,7 @@ QString corelib::createDesktopFile(const QString &prefix_name, const QString &di
     QString fileName;
 
     //FIXME:
-    QString base_icon = QString("%1/.local/share/applications/").arg(QDir::homePath());
+    QString base_icon = QString("%1/applications/").arg(this->getGenericDataLocation());
 
 #ifdef _OS_DARWIN_
     QString embedded_icon_path = QString("%1/%2.app/Contents/Resources/icons/share/q4wine/icons/").arg(APP_PREF, APP_NAME);
@@ -1102,9 +1126,7 @@ QString corelib::createDesktopFile(const QString &prefix_name, const QString &di
         fileName.append(dir_name);
         fileName.append("/");
     } else {
-        fileName = QDir::homePath();
-        fileName.append("/.config/");
-        fileName.append(APP_SHORT_NAME);
+        fileName = this->getAppConfigLocation();
         fileName.append("/tmp/");
     }
 
@@ -1181,7 +1203,7 @@ bool corelib::deleteDesktopFile(const QString &prefix_name, const QString &dir_n
     QString fileName;
 
     //FIXME:
-    QString base_icon = QString("%1/.local/share/applications/").arg(QDir::homePath());
+    QString base_icon = QString("%1/applications/").arg(this->getGenericDataLocation());
 
     fileName = base_icon;
     fileName.append(APP_SHORT_NAME);
@@ -1957,14 +1979,13 @@ bool corelib::exportPrefixesConfiguration(void){
     QStringList list = db_prefix.getPrefixList();
     QDir dir;
     QFile file;
-    QString home_path = dir.homePath();
     for (int i = 0; i < list.size(); ++i){
-        QString path = home_path;
+        QString path = this->getGenericDataLocation();
         QString prefix_name = list.at(i);
         QHash<QString,QString> result = db_prefix.getByName(prefix_name);
         QString prefix_path=result.value("path");
 
-        path.append("/.local/share/wineprefixes/");
+        path.append("/wineprefixes/");
 
         if (!dir.mkpath(path))
             return false;
@@ -1997,8 +2018,8 @@ QStringList corelib::importPrefixesConfiguration(void){
     QStringList list = db_prefix.getPrefixList();
     QDir dir;
     QFile file;
-    QString path = dir.homePath();
-    path.append("/.local/share/wineprefixes/");
+    QString path = this->getGenericDataLocation();
+    path.append("/wineprefixes/");
 
 
     dir.setFilter(QDir::Dirs | QDir::NoDotAndDotDot);

--- a/src/q4wine-lib/q4wine-lib.h
+++ b/src/q4wine-lib/q4wine-lib.h
@@ -46,6 +46,7 @@
 #include <QDesktopServices>
 #include <QUrl>
 #include <QTranslator>
+#include <QStandardPaths>
 #include <locale.h>
 
 #include "process.h"
@@ -344,6 +345,13 @@ public:
      * \return true on success.
      */
     bool removeDirectory(const QString &dirPath);
+
+    static const QString getAppConfigLocation();
+    static const QString getGenericConfigLocation();
+    static const QString getAppDataLocation();
+    static const QString getGenericDataLocation();
+    static const QString getAppCacheLocation();
+    static const QString getGenericCacheLocation();
 
 private:
     /*! Define is library operate in CLI or GUI mode.


### PR DESCRIPTION
This adds standard location getting static methods to the `corelib` class, and replaces hardcoded `.config` and `.local/share` with corresponding method calls everywhere I was able to find them.
Unless I've mistaken somewhere (which is quite possible, since I've started learning C++ very recently), the behavior in default Linux environment (i.e. when `XDG_*_HOME` vars are not set) should stay unchanged.
Fixes #179 