### PR TITLE
BUG-165: Use LC_ALL instead of LANG to force override applciation locale;

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Version 1.3.13
   - Misspelled Color Theme Settings [BUG-155];
   - CMake warning [BUG-158];
   - XDG Base Directory Specification support [BUG-178];
+  - Use LC_ALL instead of LANG to force override applciation locale [BUG-165];
 
 Version 1.3.12
  Updated:

--- a/src/q4wine-gui/prefixsettings.cpp
+++ b/src/q4wine-gui/prefixsettings.cpp
@@ -491,7 +491,7 @@ void PrefixSettings::txtRunString_Changed(){
     env.append(QString(" WINEARCH='%1' ").arg(comboArchList->currentText()));
     env.append(QString(" WINEDEBUG='%1' ").arg("-all"));
     env.append(QString(" WINEDLLOVERRIDES='' "));
-    env.append(QString(" LANG='' "));
+    env.append(QString(" LC_ALL='' "));
 
     run_string.replace("%ENV_BIN%", CoreLib->getWhichOut("env"));
     run_string.replace("%ENV_ARGS%", env);

--- a/src/q4wine-gui/uis/IconSettings.ui
+++ b/src/q4wine-gui/uis/IconSettings.ui
@@ -1048,7 +1048,7 @@
                    </size>
                   </property>
                   <property name="text">
-                   <string notr="true">LANG:</string>
+                   <string notr="true">LC_ALL:</string>
                   </property>
                  </widget>
                 </item>

--- a/src/q4wine-gui/uis/Run.ui
+++ b/src/q4wine-gui/uis/Run.ui
@@ -918,7 +918,7 @@
                    </size>
                   </property>
                   <property name="text">
-                   <string notr="true">LANG:</string>
+                   <string notr="true">LC_ALL:</string>
                   </property>
                  </widget>
                 </item>

--- a/src/q4wine-helper/wineobject.cpp
+++ b/src/q4wine-helper/wineobject.cpp
@@ -180,7 +180,7 @@ QString WineObject::createEnvString(){
         env.append(QString(" WINEDLLOVERRIDES=%1 ").arg(this->overrideDllList));
 
     if (!this->programLang.isEmpty())
-        env.append(QString(" LANG='%1' ").arg(this->programLang));
+        env.append(QString(" LC_ALL='%1' ").arg(this->programLang));
 
     return env;
 }


### PR DESCRIPTION
Implements: #165 

LANG allows you to override default locale. However wine applications not necessarily are respecting this setting.
LC_ALL variable will always override LANG and all the other LC_* variables, whether they are set or not. 

In theory, this should give better control over desired locale; 