### PR TITLE
fix: remove most of qt deprecation warnings

### DIFF
--- a/src/core/database/db.cpp
+++ b/src/core/database/db.cpp
@@ -28,7 +28,7 @@ DataBase::DataBase(QObject * parent): QObject(parent){
 #endif
 
     if (!QSqlDatabase::drivers().contains("QSQLITE")){
-        QErr<<"[EE] "<<"Critical error"<<" : "<<"Unable to load SQLite database driver. You need to compile qt-sql with SQLite database support"<<endl;
+        QErr<<"[EE] "<<"Critical error"<<" : "<<"Unable to load SQLite database driver. You need to compile qt-sql with SQLite database support"<<Qt::endl;
         return;
     }
 
@@ -41,7 +41,7 @@ DataBase::DataBase(QObject * parent): QObject(parent){
     db.setDatabaseName(db_path);
 
     if (!db.open()){
-        QErr<<"[EE] "<<"Critical error"<<" : "<<QString("Cannot open database file: %1 ; Error is: %2").arg(db_path).arg(db.lastError().text())<<endl;
+        QErr<<"[EE] "<<"Critical error"<<" : "<<QString("Cannot open database file: %1 ; Error is: %2").arg(db_path).arg(db.lastError().text())<<Qt::endl;
         return;
     }
 

--- a/src/core/database/db.h
+++ b/src/core/database/db.h
@@ -55,7 +55,7 @@ class DataBase : public QObject
     Q_OBJECT
 public:
     //! Constructor
-    explicit DataBase(QObject * parent = 0);
+    explicit DataBase(QObject * parent = nullptr);
 
     /*! \brief This function tries to check database structure.
 	*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
     CoreLib.reset(static_cast<corelib *>(CoreLibClassPointer(true)));
 
     if (!CoreLib.get()){
-        QErr<<"[EE] Cannot load shared library."<<endl;
+        QErr<<"[EE] Cannot load shared library."<<Qt::endl;
         return -1;
     }
 
@@ -111,32 +111,32 @@ int main(int argc, char *argv[])
 
     if (app.arguments().count()>1){
         if ((app.arguments().at(1)=="--version") or (app.arguments().at(1)=="-v")){
-            Qcout<<QString("%1 %2").arg(APP_SHORT_NAME).arg(APP_VERS)<<endl;
-            Qcout<<QString("Copyright (C) 2008-2021 by Oleksii S. Malakhov <brezerk@gmail.com>")<<endl;
-            Qcout<<QString("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.")<<endl;
-            Qcout<<QObject::tr("This is free software: you are free to change and redistribute it.")<<endl;
-            Qcout<<QObject::tr("There is NO WARRANTY, to the extent permitted by law.")<<endl;
+            Qcout<<QString("%1 %2").arg(APP_SHORT_NAME).arg(APP_VERS)<<Qt::endl;
+            Qcout<<QString("Copyright (C) 2008-2021 by Oleksii S. Malakhov <brezerk@gmail.com>")<<Qt::endl;
+            Qcout<<QString("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.")<<Qt::endl;
+            Qcout<<QObject::tr("This is free software: you are free to change and redistribute it.")<<Qt::endl;
+            Qcout<<QObject::tr("There is NO WARRANTY, to the extent permitted by law.")<<Qt::endl;
             CoreLib->getBuildFlags();
-            Qcout<<QObject::tr("Author: %1.").arg("Oleksii S. Malakhov")<<endl;
+            Qcout<<QObject::tr("Author: %1.").arg("Oleksii S. Malakhov")<<Qt::endl;
             return 0;
         } else if ((app.arguments().at(1)=="--minimize") or (app.arguments().at(1)=="-m")) {
             startState = 1;
         } else if ((app.arguments().at(1)=="--binary") or (app.arguments().at(1)=="-b")) {
             //startState = 1;
         } else {
-            Qcout<<QObject::tr("Usage:")<<endl;
-            Qcout<<QString("  %1 -b <unix_path_to_windown_binary>").arg(APP_SHORT_NAME)<<endl;
-            Qcout<<QObject::tr("  %1 [KEY]...").arg(APP_SHORT_NAME)<<endl;
-            Qcout<<QObject::tr("GUI utility for Wine applications and prefixes management.")<<endl<<endl;
-            Qcout<<QObject::tr("KEYs list:")<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -h,  --help"<<QObject::tr("display this help and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -v,  --version"<<QObject::tr("output version information and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -b,  --binary"<<QObject::tr("open Q4Wine run dialog for Windows binary")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -m,  --minimize"<<QObject::tr("minimize %1 main window on startup").arg(APP_SHORT_NAME)<<qSetFieldWidth(0)<<endl;
-            Qcout<<endl;
-            Qcout<<QObject::tr("Report %1 bugs to %2").arg(APP_SHORT_NAME).arg(APP_BUG_EMAIL)<<endl;
-            Qcout<<QObject::tr("%1 homepage: <%2>").arg(APP_SHORT_NAME).arg(APP_WEBSITE)<<endl;
-            Qcout<<QObject::tr("General help using GNU software: <http://www.gnu.org/gethelp/>")<<endl;
+            Qcout<<QObject::tr("Usage:")<<Qt::endl;
+            Qcout<<QString("  %1 -b <unix_path_to_windown_binary>").arg(APP_SHORT_NAME)<<Qt::endl;
+            Qcout<<QObject::tr("  %1 [KEY]...").arg(APP_SHORT_NAME)<<Qt::endl;
+            Qcout<<QObject::tr("GUI utility for Wine applications and prefixes management.")<<Qt::endl<<Qt::endl;
+            Qcout<<QObject::tr("KEYs list:")<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -h,  --help"<<QObject::tr("display this help and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -v,  --version"<<QObject::tr("output version information and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -b,  --binary"<<QObject::tr("open Q4Wine run dialog for Windows binary")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -m,  --minimize"<<QObject::tr("minimize %1 main window on startup").arg(APP_SHORT_NAME)<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<Qt::endl;
+            Qcout<<QObject::tr("Report %1 bugs to %2").arg(APP_SHORT_NAME).arg(APP_BUG_EMAIL)<<Qt::endl;
+            Qcout<<QObject::tr("%1 homepage: <%2>").arg(APP_SHORT_NAME).arg(APP_WEBSITE)<<Qt::endl;
+            Qcout<<QObject::tr("General help using GNU software: <http://www.gnu.org/gethelp/>")<<Qt::endl;
             return 0;
         }
     }
@@ -152,14 +152,14 @@ int main(int argc, char *argv[])
     DataBase db;
 
     if (!db.checkDb()){
-        QErr<<"[EE] Cannot initialize database engine."<<endl;
+        QErr<<"[EE] Cannot initialize database engine."<<Qt::endl;
         return -1;
     }
 
     if (!CoreLib->isConfigured()){
         Wizard firstSetupWizard(1);
         if (firstSetupWizard.exec()==QDialog::Rejected){
-            QErr<<"[EE] Application not configured! Rerun the setup wizard or delete broken Q4Wine configuration files."<<endl;
+            QErr<<"[EE] Application not configured! Rerun the setup wizard or delete broken Q4Wine configuration files."<<Qt::endl;
             return -1;
         }
     }

--- a/src/plugins/sysmenu.cpp
+++ b/src/plugins/sysmenu.cpp
@@ -284,7 +284,7 @@ bool system_menu::writeXMLSystemMenu(){
         return false;
 
     QTextStream out(&file);
-    out<<menu_xml.toString()<<endl;
+    out<<menu_xml.toString()<<Qt::endl;
 
     file.close();
 

--- a/src/q4wine-cli/q4wine-cli.cpp
+++ b/src/q4wine-cli/q4wine-cli.cpp
@@ -69,46 +69,46 @@ int main(int argc, char *argv[])
 
     for (int i=1; i<argc; i++){
         if ((app.arguments().at(i)=="--help") or (app.arguments().at(i)=="-h")){
-            Qcout<<QObject::tr("Usage:")<<endl;
-            Qcout<<QObject::tr("  %1-cli [KEY]...").arg(APP_SHORT_NAME)<<endl;
-            Qcout<<QObject::tr("  %1-cli -p <prefix_name> [-d <dir_name>] -i <icon_name>").arg(APP_SHORT_NAME)<<endl;
-            Qcout<<QObject::tr("  %1-cli -p <prefix_name> -b <windows_binary_path> [args]").arg(APP_SHORT_NAME)<<endl;
-            Qcout<<QObject::tr("Console utility for wine applications and prefixes management.")<<endl<<endl;
-            Qcout<<QObject::tr("KEYs list:")<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -h,  --help"<<QObject::tr("display this help and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -v,  --version"<<QObject::tr("output version information and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -ps, --procs"<<QObject::tr("output wine process list for current prefix or for all prefixes and exit ")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -p,  --prefix"<<QObject::tr("sets the current prefix name")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -d,  --dir"<<QObject::tr("sets the current directory name")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -i,  --icon"<<QObject::tr("sets the current icon name")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -cd, --cdimage"<<QObject::tr("sets the cd image name")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -b, --binary"<<QObject::tr("sets the path to windows binary for execute with current prefix settings")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -k,  --kill"<<QObject::tr("sends -9 term signal to current prefix process or for all prefixes processes")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -pl, --prefixlist"<<QObject::tr("output all existing prefixes names and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -dl, --dirlist"<<QObject::tr("output all existing dir names for current prefix and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -il, --iconlist"<<QObject::tr("output all existing icon names for current prefix/directory and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -cl, --cdlist"<<QObject::tr("output all cd images list and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -ml, --mountlist"<<QObject::tr("output all mounted media for current prefix or all prefixes and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -m,  --mount"<<QObject::tr("mount a cd image or drive for current prefix and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  -u,  --umount"<<QObject::tr("unmount a cd image or drive for current prefix and exit")<<qSetFieldWidth(0)<<endl;
-            Qcout<<endl;
-            Qcout<<QObject::tr("Exit status:")<<endl;
-            Qcout<<QObject::tr("  0 if OK,")<<endl;
-            Qcout<<QObject::tr(" -1 if serious troubles")<<endl;
-            Qcout<<endl;
-            Qcout<<QObject::tr("Report %1 bugs to %2").arg(APP_SHORT_NAME).arg(APP_BUG_EMAIL)<<endl;
-            Qcout<<QObject::tr("%1 homepage: <%2>").arg(APP_WEBSITE).arg(APP_SHORT_NAME)<<endl;
-            Qcout<<QObject::tr("General help using GNU software: <http://www.gnu.org/gethelp/>")<<endl;
+            Qcout<<QObject::tr("Usage:")<<Qt::endl;
+            Qcout<<QObject::tr("  %1-cli [KEY]...").arg(APP_SHORT_NAME)<<Qt::endl;
+            Qcout<<QObject::tr("  %1-cli -p <prefix_name> [-d <dir_name>] -i <icon_name>").arg(APP_SHORT_NAME)<<Qt::endl;
+            Qcout<<QObject::tr("  %1-cli -p <prefix_name> -b <windows_binary_path> [args]").arg(APP_SHORT_NAME)<<Qt::endl;
+            Qcout<<QObject::tr("Console utility for wine applications and prefixes management.")<<Qt::endl<<Qt::endl;
+            Qcout<<QObject::tr("KEYs list:")<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -h,  --help"<<QObject::tr("display this help and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -v,  --version"<<QObject::tr("output version information and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -ps, --procs"<<QObject::tr("output wine process list for current prefix or for all prefixes and exit ")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -p,  --prefix"<<QObject::tr("sets the current prefix name")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -d,  --dir"<<QObject::tr("sets the current directory name")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -i,  --icon"<<QObject::tr("sets the current icon name")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -cd, --cdimage"<<QObject::tr("sets the cd image name")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -b, --binary"<<QObject::tr("sets the path to windows binary for execute with current prefix settings")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -k,  --kill"<<QObject::tr("sends -9 term signal to current prefix process or for all prefixes processes")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -pl, --prefixlist"<<QObject::tr("output all existing prefixes names and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -dl, --dirlist"<<QObject::tr("output all existing dir names for current prefix and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -il, --iconlist"<<QObject::tr("output all existing icon names for current prefix/directory and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -cl, --cdlist"<<QObject::tr("output all cd images list and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -ml, --mountlist"<<QObject::tr("output all mounted media for current prefix or all prefixes and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -m,  --mount"<<QObject::tr("mount a cd image or drive for current prefix and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  -u,  --umount"<<QObject::tr("unmount a cd image or drive for current prefix and exit")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<Qt::endl;
+            Qcout<<QObject::tr("Exit status:")<<Qt::endl;
+            Qcout<<QObject::tr("  0 if OK,")<<Qt::endl;
+            Qcout<<QObject::tr(" -1 if serious troubles")<<Qt::endl;
+            Qcout<<Qt::endl;
+            Qcout<<QObject::tr("Report %1 bugs to %2").arg(APP_SHORT_NAME).arg(APP_BUG_EMAIL)<<Qt::endl;
+            Qcout<<QObject::tr("%1 homepage: <%2>").arg(APP_WEBSITE).arg(APP_SHORT_NAME)<<Qt::endl;
+            Qcout<<QObject::tr("General help using GNU software: <http://www.gnu.org/gethelp/>")<<Qt::endl;
             return 0;
         }
         if ((app.arguments().at(i)=="--version") or (app.arguments().at(i)=="-v")){
-            Qcout<<QString("%1-cli %2").arg(APP_SHORT_NAME).arg(APP_VERS)<<endl;
-            Qcout<<QString("Copyright (C) 2008-2021 by Oleksii S. Malakhov <brezerk@gmail.com>")<<endl;
-            Qcout<<QString("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.")<<endl;
-            Qcout<<QObject::tr("This is free software: you are free to change and redistribute it.")<<endl;
-            Qcout<<QObject::tr("There is NO WARRANTY, to the extent permitted by law.")<<endl;
+            Qcout<<QString("%1-cli %2").arg(APP_SHORT_NAME).arg(APP_VERS)<<Qt::endl;
+            Qcout<<QString("Copyright (C) 2008-2021 by Oleksii S. Malakhov <brezerk@gmail.com>")<<Qt::endl;
+            Qcout<<QString("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.")<<Qt::endl;
+            Qcout<<QObject::tr("This is free software: you are free to change and redistribute it.")<<Qt::endl;
+            Qcout<<QObject::tr("There is NO WARRANTY, to the extent permitted by law.")<<Qt::endl;
             CoreLib->getBuildFlags();
-            Qcout<<QObject::tr("Author: %1.").arg("Oleksii S. Malakhov")<<endl;
+            Qcout<<QObject::tr("Author: %1.").arg("Oleksii S. Malakhov")<<Qt::endl;
             return 0;
         }
     }
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     Image db_image;
 
     if (!CoreLib->isConfigured()){
-        QErr<<"[EE] App not configured! Rerun wizard, or delete Q4Wine broken config files."<<endl;
+        QErr<<"[EE] App not configured! Rerun wizard, or delete Q4Wine broken config files."<<Qt::endl;
         return -1;
     }
 
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
                 continue;
             }
             if (!db_prefix.isExistsByName(_PREFIX)){
-                Qcout<<QObject::tr("Prefix named \"%1\" does not exist. Run \"%2-cli -pl\" for prefix list.").arg(_PREFIX).arg(APP_SHORT_NAME)<<endl;
+                Qcout<<QObject::tr("Prefix named \"%1\" does not exist. Run \"%2-cli -pl\" for prefix list.").arg(_PREFIX).arg(APP_SHORT_NAME)<<Qt::endl;
                 return -1;
             }
         }
@@ -226,14 +226,14 @@ int main(int argc, char *argv[])
 
     if (_ACTION==2){
         QStringList list = db_prefix.getPrefixList();
-        Qcout<<QObject::tr("Prefix list")<<endl;
-        Qcout<<" "<<qSetFieldWidth(15)<<left<<QObject::tr("Name")<<QObject::tr("Path")<<qSetFieldWidth(0)<<endl;
+        Qcout<<QObject::tr("Prefix list")<<Qt::endl;
+        Qcout<<" "<<qSetFieldWidth(15)<<Qt::left<<QObject::tr("Name")<<QObject::tr("Path")<<qSetFieldWidth(0)<<Qt::endl;
         for (int i = 0; i < list.size(); ++i) {
             QString path = db_prefix.getPath(list.at(i));
             if (!path.isEmpty()){
-                Qcout<<" "<<qSetFieldWidth(15)<<left<<list.at(i)<<path<<qSetFieldWidth(0)<<endl;
+                Qcout<<" "<<qSetFieldWidth(15)<<Qt::left<<list.at(i)<<path<<qSetFieldWidth(0)<<Qt::endl;
             } else {
-                Qcout<<" "<<qSetFieldWidth(15)<<left<<list.at(i)<<QDir::homePath()<<"/.wine/"<<qSetFieldWidth(0)<<endl;
+                Qcout<<" "<<qSetFieldWidth(15)<<Qt::left<<list.at(i)<<QDir::homePath()<<"/.wine/"<<qSetFieldWidth(0)<<Qt::endl;
             }
         }
         return 0;
@@ -248,24 +248,24 @@ int main(int argc, char *argv[])
     case 0:
         // Running selected icon
         if (_PREFIX.isEmpty()){
-            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<endl;
+            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<Qt::endl;
             return -1;
         }
 
         if (_ICON.isEmpty()){
-            Qcout<<QObject::tr("No current icon set. Set icon via \"-i <icon_name>\" key.")<<endl;
+            Qcout<<QObject::tr("No current icon set. Set icon via \"-i <icon_name>\" key.")<<Qt::endl;
             return -1;
         }
 
         if (!db_icon.isExistsByName(_PREFIX, _DIR, _ICON)){
-            Qcout<<QObject::tr("Icon named \"%1\" does not exist.  Run \"%2-cli -il\" for icon list.").arg(_ICON).arg(APP_SHORT_NAME)<<endl;
+            Qcout<<QObject::tr("Icon named \"%1\" does not exist.  Run \"%2-cli -il\" for icon list.").arg(_ICON).arg(APP_SHORT_NAME)<<Qt::endl;
             return -1;
         }
 
         if (CoreLib->runIcon(_PREFIX, _DIR, _ICON, extra_args)){
-            Qcout<<"Done"<<endl;
+            Qcout<<"Done"<<Qt::endl;
         } else {
-            Qcout<<"Error"<<endl;
+            Qcout<<"Error"<<Qt::endl;
             return -1;
         }
         break;
@@ -273,104 +273,104 @@ int main(int argc, char *argv[])
         // Show wine process list
         result = CoreLib->getWineProcessList();
         if (_PREFIX.isEmpty()){
-            Qcout<<QObject::tr("Wine process list")<<endl;
+            Qcout<<QObject::tr("Wine process list")<<Qt::endl;
         } else {
-            Qcout<<QObject::tr("Wine process list for \"%1\" prefix").arg(_PREFIX)<<endl;
+            Qcout<<QObject::tr("Wine process list for \"%1\" prefix").arg(_PREFIX)<<Qt::endl;
             path = db_prefix.getPath(_PREFIX);
         }
         // Process QList items one by one
-        Qcout<<" "<<qSetFieldWidth(8)<<left<<QObject::tr("PID")<<qSetFieldWidth(6)<<left<<QObject::tr("Nice")<<qSetFieldWidth(20)<<left<<QObject::tr("Name")<<QObject::tr("Prefix path")<<qSetFieldWidth(0)<<endl;
+        Qcout<<" "<<qSetFieldWidth(8)<<Qt::left<<QObject::tr("PID")<<qSetFieldWidth(6)<<Qt::left<<QObject::tr("Nice")<<qSetFieldWidth(20)<<Qt::left<<QObject::tr("Name")<<QObject::tr("Prefix path")<<qSetFieldWidth(0)<<Qt::endl;
         for (int i = 0; i < result.size(); ++i) {
             if (_PREFIX.isEmpty()){
-                Qcout<<" "<<qSetFieldWidth(8)<<left<<result.at(i).at(0)<<qSetFieldWidth(6)<<left<<result.at(i).at(2)<<qSetFieldWidth(20)<<left<<result.at(i).at(1)<<result.at(i).at(3)<<qSetFieldWidth(0)<<endl;
+                Qcout<<" "<<qSetFieldWidth(8)<<Qt::left<<result.at(i).at(0)<<qSetFieldWidth(6)<<Qt::left<<result.at(i).at(2)<<qSetFieldWidth(20)<<Qt::left<<result.at(i).at(1)<<result.at(i).at(3)<<qSetFieldWidth(0)<<Qt::endl;
             } else {
                 if (path==result.at(i).at(3))
-                    Qcout<<" "<<qSetFieldWidth(8)<<left<<result.at(i).at(0)<<qSetFieldWidth(6)<<left<<result.at(i).at(2)<<qSetFieldWidth(20)<<left<<result.at(i).at(1)<<result.at(i).at(3)<<qSetFieldWidth(0)<<endl;
+                    Qcout<<" "<<qSetFieldWidth(8)<<Qt::left<<result.at(i).at(0)<<qSetFieldWidth(6)<<Qt::left<<result.at(i).at(2)<<qSetFieldWidth(20)<<Qt::left<<result.at(i).at(1)<<result.at(i).at(3)<<qSetFieldWidth(0)<<Qt::endl;
             }
         }
         break;
     case 3:
         if (_PREFIX.isEmpty()){
-            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<endl;
+            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<Qt::endl;
             return -1;
         } else {
             QStringList list = db_dir.getDirList(_PREFIX);
-            Qcout<<QObject::tr("Prefix \"%1\" has following dir list").arg(_PREFIX)<<endl;
-            Qcout<<" "<<QObject::tr("Name")<<endl;
+            Qcout<<QObject::tr("Prefix \"%1\" has following dir list").arg(_PREFIX)<<Qt::endl;
+            Qcout<<" "<<QObject::tr("Name")<<Qt::endl;
             for (int i = 0; i < list.size(); ++i) {
-                Qcout<<" "<<list.at(i)<<endl;
+                Qcout<<" "<<list.at(i)<<Qt::endl;
             }
         }
         break;
     case 4:
         if (_PREFIX.isEmpty()){
-            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<endl;
+            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<Qt::endl;
             return -1;
         }
 
         if (! db_dir.isExistsByName(_PREFIX, _DIR)){
-            Qcout<<QObject::tr("Dir named \"%1\" does not exist. Run \"%2-cli -dl\" for dir list.").arg(_DIR).arg(APP_SHORT_NAME)<<endl;
+            Qcout<<QObject::tr("Dir named \"%1\" does not exist. Run \"%2-cli -dl\" for dir list.").arg(_DIR).arg(APP_SHORT_NAME)<<Qt::endl;
             return -1;
         } else {
             QStringList list = db_icon.getIconsList(_PREFIX, _DIR, "");
             if (_DIR.isEmpty()){
-                Qcout<<QObject::tr("Prefix \"%1\" has following icon list").arg(_PREFIX)<<endl;
+                Qcout<<QObject::tr("Prefix \"%1\" has following icon list").arg(_PREFIX)<<Qt::endl;
             } else {
-                Qcout<<QObject::tr("Prefix \"%1\" has following icon list at \"%2\" directory").arg(_PREFIX).arg(_DIR)<<endl;
+                Qcout<<QObject::tr("Prefix \"%1\" has following icon list at \"%2\" directory").arg(_PREFIX).arg(_DIR)<<Qt::endl;
             }
-            Qcout<<" "<<qSetFieldWidth(15)<<left<<QObject::tr("Name")<<QObject::tr("Description")<<qSetFieldWidth(0)<<endl;
+            Qcout<<" "<<qSetFieldWidth(15)<<Qt::left<<QObject::tr("Name")<<QObject::tr("Description")<<qSetFieldWidth(0)<<Qt::endl;
 
             for (int i = 0; i < list.size(); ++i) {
-                Qcout<<" "<<qSetFieldWidth(15)<<left<<list.at(i)<<db_icon.getByName(_PREFIX, _DIR, list.at(i)).value("desc")<<qSetFieldWidth(0)<<endl;
+                Qcout<<" "<<qSetFieldWidth(15)<<Qt::left<<list.at(i)<<db_icon.getByName(_PREFIX, _DIR, list.at(i)).value("desc")<<qSetFieldWidth(0)<<Qt::endl;
             }
         }
         break;
     case 5:
         result = db_image.getFields();
-        Qcout<<QObject::tr("%1 has the following disc images in the database").arg(APP_SHORT_NAME)<<endl;
-        Qcout<<" "<<qSetFieldWidth(25)<<left<<QObject::tr("Name")<<QObject::tr("Path")<<qSetFieldWidth(0)<<endl;
+        Qcout<<QObject::tr("%1 has the following disc images in the database").arg(APP_SHORT_NAME)<<Qt::endl;
+        Qcout<<" "<<qSetFieldWidth(25)<<Qt::left<<QObject::tr("Name")<<QObject::tr("Path")<<qSetFieldWidth(0)<<Qt::endl;
         for (int i = 0; i < result.size(); ++i) {
-            Qcout<<" "<<qSetFieldWidth(25)<<left<<result.at(i).at(0)<<result.at(i).at(1)<<qSetFieldWidth(0)<<endl;
+            Qcout<<" "<<qSetFieldWidth(25)<<Qt::left<<result.at(i).at(0)<<result.at(i).at(1)<<qSetFieldWidth(0)<<Qt::endl;
         }
         break;
     case 6:
         if (_PREFIX.isEmpty()){
-            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<endl;
+            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<Qt::endl;
             return -1;
         } else {
-            Qcout<<QObject::tr("Killing prefix \"%1\" wineserver.").arg(_PREFIX)<<endl;
+            Qcout<<QObject::tr("Killing prefix \"%1\" wineserver.").arg(_PREFIX)<<Qt::endl;
             if (CoreLib->killWineServer(db_prefix.getPath(_PREFIX), "")){
-                Qcout<<"Done"<<endl;
+                Qcout<<"Done"<<Qt::endl;
             } else {
-                Qcout<<"Error"<<endl;
+                Qcout<<"Error"<<Qt::endl;
                 return -1;
             }
         }
         break;
     case 7:
         if (_PREFIX.isEmpty()){
-            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<endl;
+            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<Qt::endl;
             return -1;
         } else {
             QString mount = db_prefix.getMountPoint(_PREFIX);
 
             if (mount.isEmpty()){
-                Qcout<<QObject::tr("No mount point set in prefix configuration.")<<endl;
+                Qcout<<QObject::tr("No mount point set in prefix configuration.")<<Qt::endl;
                 return -1;
             }
 
             if (!_IMAGE.isEmpty()){
                 if (!QFile(_IMAGE).exists()){
                     if (!db_image.isExistsByName(_IMAGE)){
-                        Qcout<<QObject::tr("Disc image named \"%1\" does not exist. Run \"%2-cli -cl\" for disc image list.").arg(_IMAGE).arg(APP_SHORT_NAME)<<endl;
+                        Qcout<<QObject::tr("Disc image named \"%1\" does not exist. Run \"%2-cli -cl\" for disc image list.").arg(_IMAGE).arg(APP_SHORT_NAME)<<Qt::endl;
                         return -1;
                     }
                 }
 
                 if (CoreLib->mountImage(_IMAGE, _PREFIX)){
-                    Qcout<<"Done"<<endl;
+                    Qcout<<"Done"<<Qt::endl;
                 } else {
-                    Qcout<<"Error"<<endl;
+                    Qcout<<"Error"<<Qt::endl;
                     return -1;
                 }
             }
@@ -378,21 +378,21 @@ int main(int argc, char *argv[])
         break;
     case 8:
         if (_PREFIX.isEmpty()){
-            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<endl;
+            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<Qt::endl;
             return -1;
         } else {
             QString mount = db_prefix.getMountPoint(_PREFIX);
 
             if (mount.isEmpty()){
-                Qcout<<QObject::tr("No mount point set in prefix configuration.")<<endl;
+                Qcout<<QObject::tr("No mount point set in prefix configuration.")<<Qt::endl;
                 return -1;
             }
 
-            Qcout<<QObject::tr("Unmounting mount point \"%1\".").arg(mount)<<endl;
+            Qcout<<QObject::tr("Unmounting mount point \"%1\".").arg(mount)<<Qt::endl;
             if (CoreLib->umountImage(_PREFIX)){
-                Qcout<<"Done"<<endl;
+                Qcout<<"Done"<<Qt::endl;
             } else {
-                Qcout<<"Error"<<endl;
+                Qcout<<"Error"<<Qt::endl;
                 return -1;
             }
         }
@@ -400,35 +400,35 @@ int main(int argc, char *argv[])
     case 10:
         if (_PREFIX.isEmpty()){
             QStringList list = db_prefix.getPrefixList();
-            Qcout<<QObject::tr("Mounted media list for all prefixes")<<endl;
-            Qcout<<" "<<qSetFieldWidth(15)<<left<<QObject::tr("Prefix")<<qSetFieldWidth(25)<<left<<QObject::tr("Mount point")<<QObject::tr("Media")<<qSetFieldWidth(0)<<endl;
+            Qcout<<QObject::tr("Mounted media list for all prefixes")<<Qt::endl;
+            Qcout<<" "<<qSetFieldWidth(15)<<Qt::left<<QObject::tr("Prefix")<<qSetFieldWidth(25)<<Qt::left<<QObject::tr("Mount point")<<QObject::tr("Media")<<qSetFieldWidth(0)<<Qt::endl;
             for (int i = 0; i < list.size(); ++i) {
                 QString mount = db_prefix.getMountPoint(list.at(i));
-                Qcout<<" "<<qSetFieldWidth(15)<<left<<list.at(i)<<qSetFieldWidth(25)<<left<<mount<<CoreLib->getMountedImages(mount)<<qSetFieldWidth(0)<<endl;
+                Qcout<<" "<<qSetFieldWidth(15)<<Qt::left<<list.at(i)<<qSetFieldWidth(25)<<Qt::left<<mount<<CoreLib->getMountedImages(mount)<<qSetFieldWidth(0)<<Qt::endl;
             }
         } else {
             QString mount = db_prefix.getMountPoint(_PREFIX);
 
             if (mount.isEmpty()){
-                Qcout<<QObject::tr("No mount point set in prefix configuration.")<<endl;
+                Qcout<<QObject::tr("No mount point set in prefix configuration.")<<Qt::endl;
                 return -1;
             }
 
-            Qcout<<QObject::tr("Mounted media list for prefix \"%1\"").arg(_PREFIX)<<endl;
-            Qcout<<" "<<qSetFieldWidth(25)<<left<<QObject::tr("Mount point")<<QObject::tr("Media")<<qSetFieldWidth(0)<<endl;
-            Qcout<<" "<<qSetFieldWidth(25)<<left<<mount<<CoreLib->getMountedImages(mount)<<qSetFieldWidth(0)<<endl;
+            Qcout<<QObject::tr("Mounted media list for prefix \"%1\"").arg(_PREFIX)<<Qt::endl;
+            Qcout<<" "<<qSetFieldWidth(25)<<Qt::left<<QObject::tr("Mount point")<<QObject::tr("Media")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<" "<<qSetFieldWidth(25)<<Qt::left<<mount<<CoreLib->getMountedImages(mount)<<qSetFieldWidth(0)<<Qt::endl;
         }
         break;
     case 12:
         if (_PREFIX.isEmpty()){
-            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<endl;
+            Qcout<<QObject::tr("No current prefix set. Set prefix via \"-p <prefix_name>\" key.")<<Qt::endl;
             return -1;
         }
 
         qDebug()<<_IMAGE;
 
         if (!QFile(_IMAGE).exists()){
-            Qcout<<QObject::tr("File \"%1\" does not exist.").arg(_IMAGE)<<endl;
+            Qcout<<QObject::tr("File \"%1\" does not exist.").arg(_IMAGE)<<Qt::endl;
             return -1;
         }
 
@@ -443,9 +443,9 @@ int main(int argc, char *argv[])
         execObj.desktop = "";
         execObj.execcmd=_IMAGE;
         if (CoreLib->runWineBinary(execObj, _PREFIX)){
-            Qcout<<"Done"<<endl;
+            Qcout<<"Done"<<Qt::endl;
         } else {
-            Qcout<<"Error"<<endl;
+            Qcout<<"Error"<<Qt::endl;
             return -1;
         }
         break;

--- a/src/q4wine-gui/about.h
+++ b/src/q4wine-gui/about.h
@@ -30,7 +30,7 @@ class About : public QDialog, public Ui::About
 {
 	Q_OBJECT
 public:
-    About(QWidget * parent = 0, Qt::WindowFlags f = 0);
+    About(QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
 private:
     //! This is need for libq4wine-core.so import.

--- a/src/q4wine-gui/appsettings.h
+++ b/src/q4wine-gui/appsettings.h
@@ -36,7 +36,7 @@ class AppSettings : public QDialog, public Ui::AppSettings
 {
     Q_OBJECT
     public:
-        AppSettings(QWidget * parent = 0, Qt::WindowFlags f = 0);
+        AppSettings(QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
     private slots:
         void cmdCancel_Click();

--- a/src/q4wine-gui/fakedrivesettings.h
+++ b/src/q4wine-gui/fakedrivesettings.h
@@ -52,7 +52,7 @@ class FakeDriveSettings : public QDialog, public Ui::FakeDriveSettings
 {
     Q_OBJECT
 public:
-    explicit FakeDriveSettings(QString prefixName, QWidget * parent = 0, Qt::WindowFlags f = 0);
+    explicit FakeDriveSettings(QString prefixName, QWidget * parent = nullptr, Qt::WindowFlags f =  Qt::WindowFlags());
     void loadPrefixSettings();
     void loadDefaultPrefixSettings();
 

--- a/src/q4wine-gui/iconsettings.h
+++ b/src/q4wine-gui/iconsettings.h
@@ -63,7 +63,7 @@ class IconSettings : public QDialog, public Ui::IconSettings
          * \param  dir_name		Current directory name.
          * \param  icon_name	Current directory name.
          */
-        IconSettings(QString prefix_name, QString dir_name, QString icon_name = "", QWidget * parent = 0, Qt::WindowFlags f = 0);
+        IconSettings(QString prefix_name, QString dir_name, QString icon_name = "", QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
     private slots:
         /*! \brief This slot function adds selected dll to override list.

--- a/src/q4wine-gui/iconsview.h
+++ b/src/q4wine-gui/iconsview.h
@@ -38,7 +38,7 @@ class IconsView : public QDialog, public Ui::IconsView
 {
 	Q_OBJECT
 	public:
-		IconsView(QString tmpDir, QWidget * parent = 0, Qt::WindowFlags f = 0);
+		IconsView(QString tmpDir, QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 		QString selectedFile;
 
 	private slots:

--- a/src/q4wine-gui/imagemanager.h
+++ b/src/q4wine-gui/imagemanager.h
@@ -46,7 +46,7 @@ class ImageManager : public QDialog, public Ui::ImageManager
 	Q_OBJECT
 	public:
 		//! Class constructor
-		ImageManager(QWidget * parent = 0, Qt::WindowFlags f = 0);
+		ImageManager(QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
 	private slots:
 		//! Ok button click slot

--- a/src/q4wine-gui/mainwindow.cpp
+++ b/src/q4wine-gui/mainwindow.cpp
@@ -381,7 +381,7 @@ bool MainWindow::createSocket(){
 
     if (!serverSoket->listen(soketFile)){
         QTextStream QErr(stderr);
-        QErr<<"[EE] Cannot create Q4Wine socket: "<<serverSoket->errorString()<<endl;
+        QErr<<"[EE] Cannot create Q4Wine socket: "<<serverSoket->errorString()<<Qt::endl;
         exit(255);
     }
 

--- a/src/q4wine-gui/mainwindow.cpp
+++ b/src/q4wine-gui/mainwindow.cpp
@@ -701,7 +701,7 @@ void MainWindow::mainImageManager_Click(){
      * Disc Image Manager
      */
 
-    ImageManager manager(0);
+    ImageManager manager(nullptr);
     manager.exec();
 
     return;

--- a/src/q4wine-gui/mainwindow.h
+++ b/src/q4wine-gui/mainwindow.h
@@ -95,8 +95,8 @@ class MainWindow : public QMainWindow, public Ui::MainWindow
 public:
     MainWindow(const int startState,
                const QString &run_binary,
-               QWidget * parent = 0,
-               const Qt::WindowFlags f = 0);
+               QWidget * parent = nullptr,
+               const Qt::WindowFlags f = Qt::WindowFlags());
 
 public slots:
     void messageReceived(const QString &message);

--- a/src/q4wine-gui/prefixsettings.cpp
+++ b/src/q4wine-gui/prefixsettings.cpp
@@ -124,7 +124,7 @@ PrefixSettings::PrefixSettings(QString prefix_name, QWidget * parent, Qt::Window
     connect(cmdClnWineLibs, SIGNAL(clicked()), this, SLOT(cmdClnWineLibs_Click()));
 
     connect(comboVersionList, SIGNAL(currentIndexChanged(const QString)), this, SLOT(comboVersionList_Change(const QString)));
-    connect(comboTemplatesList, SIGNAL(currentIndexChanged(const int)), this, SLOT(comboTemplatesList_Change(const int)));
+    connect(comboTemplatesList, SIGNAL(currentIndexChanged(const int)), this, SLOT(comboTemplatesList_Change(int)));
     connect(cmdAddVersion, SIGNAL(clicked()), this, SLOT(cmdAddVersion_Click()));
 
     getVersionsList();
@@ -185,7 +185,7 @@ PrefixSettings::PrefixSettings(QWidget * parent, Qt::WindowFlags f) : QDialog(pa
     connect(txtPrefixName, SIGNAL(textChanged(QString)), this, SLOT(setDefPath(QString)));
 
     connect(comboVersionList, SIGNAL(currentIndexChanged(const QString)), this, SLOT(comboVersionList_Change(const QString)));
-    connect(comboTemplatesList, SIGNAL(currentIndexChanged(const int)), this, SLOT(comboTemplatesList_Change(const int)));
+    connect(comboTemplatesList, SIGNAL(currentIndexChanged(const int)), this, SLOT(comboTemplatesList_Change(int)));
     connect(cmdAddVersion, SIGNAL(clicked()), this, SLOT(cmdAddVersion_Click()));
 
     getVersionsList();
@@ -430,7 +430,7 @@ void PrefixSettings::comboVersionList_Change(const QString & text){
     //version_name = text;
 }
 
-void PrefixSettings::comboTemplatesList_Change(const int id){
+void PrefixSettings::comboTemplatesList_Change(int id){
     if (id == 1){
         txtRunString->setText(RUN_STRING_TEMPLATE_DEFAULT);
     } else if (id == 2){

--- a/src/q4wine-gui/prefixsettings.h
+++ b/src/q4wine-gui/prefixsettings.h
@@ -53,8 +53,8 @@ class PrefixSettings : public QDialog, public Ui::PrefixSettings
          *
          * \param  prefix_name  Current prefix name.
          */
-        PrefixSettings(QString prefix_name, QWidget * parent = 0, Qt::WindowFlags f = 0);
-        PrefixSettings(QWidget * parent = 0, Qt::WindowFlags f = 0);
+        PrefixSettings(QString prefix_name, QWidget * parent = nullptr, Qt::WindowFlags f = 0);
+        PrefixSettings(QWidget * parent = nullptr, Qt::WindowFlags f = 0);
         QString getPrefixName();
 
     private:
@@ -63,7 +63,7 @@ class PrefixSettings : public QDialog, public Ui::PrefixSettings
          * This event filter handle button click events
          * \param  prefix_name  Current prefix name.
          */
-        bool eventFilter(QObject *obj, QEvent *event);
+        bool eventFilter(QObject *obj, QEvent *event) override;
 
         /*! \brief This function loads theme images to widgets.
          *
@@ -127,7 +127,7 @@ class PrefixSettings : public QDialog, public Ui::PrefixSettings
         void cmdAddVersion_Click();
 
         void comboVersionList_Change(const QString & text);
-        void comboTemplatesList_Change(const int id);
+        void comboTemplatesList_Change(int id);
 
         void txtRunString_Changed();
 };

--- a/src/q4wine-gui/prefixsettings.h
+++ b/src/q4wine-gui/prefixsettings.h
@@ -53,8 +53,8 @@ class PrefixSettings : public QDialog, public Ui::PrefixSettings
          *
          * \param  prefix_name  Current prefix name.
          */
-        PrefixSettings(QString prefix_name, QWidget * parent = nullptr, Qt::WindowFlags f = 0);
-        PrefixSettings(QWidget * parent = nullptr, Qt::WindowFlags f = 0);
+        PrefixSettings(QString prefix_name, QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+        PrefixSettings(QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
         QString getPrefixName();
 
     private:

--- a/src/q4wine-gui/process.cpp
+++ b/src/q4wine-gui/process.cpp
@@ -57,8 +57,8 @@ void Process::slotError(QProcess::ProcessError err){
 
 		QTextCodec *codec = QTextCodec::codecForName(lang.toLatin1());
 		if (!codec){
-			stdErr<<"[ee] Cannot setup codec for \""<<lang<<"\""<<endl;
-			stdErr<<"[ee] Aborting current operation!"<<endl;
+			stdErr<<"[ee] Cannot setup codec for \""<<lang<<"\""<<Qt::endl;
+			stdErr<<"[ee] Aborting current operation!"<<Qt::endl;
 			reject();
 			return;
 		}
@@ -130,8 +130,8 @@ void Process::slotFinished(int, QProcess::ExitStatus exitc){
 		// Read STDERR with locale support
 		QTextCodec *codec = QTextCodec::codecForName(lang.toLatin1());
 		if (!codec){
-			stdErr<<"[ee] Cannot setup codec for \""<<lang<<"\""<<endl;
-			stdErr<<"[ee] Aborting current operation!"<<endl;
+			stdErr<<"[ee] Cannot setup codec for \""<<lang<<"\""<<Qt::endl;
+			stdErr<<"[ee] Aborting current operation!"<<Qt::endl;
 			reject();
 			return;
 		}

--- a/src/q4wine-gui/process.h
+++ b/src/q4wine-gui/process.h
@@ -31,7 +31,7 @@
 #include <QLibrary>
 #include <QTextCodec>
 #include <QTextStream>
-#include <locale.h>
+#include <clocale>
 
 #ifdef DEBUG
 #include <QDebug>
@@ -41,11 +41,11 @@ class Process : public QDialog, public Ui::Process
 {
 	Q_OBJECT
 	public:
-		Process(QStringList args, QString exec, QString dir, QString info, QString caption, bool showErr = true, QStringList env = QProcess::systemEnvironment(), QWidget * parent = 0, Qt::WindowFlags f = 0);
+		Process(QStringList args, QString exec, QString dir, QString info, QString caption, bool showErr = true, QStringList env = QProcess::systemEnvironment(), QWidget * parent = nullptr, Qt::WindowFlags f = Qt::Widget);
 
 	private slots:
 		void slotFinished(int, QProcess::ExitStatus);
-		void cmdCancel_clicked(void);
+		void cmdCancel_clicked();
 		void slotError(QProcess::ProcessError);
 
 	private:

--- a/src/q4wine-gui/progress.h
+++ b/src/q4wine-gui/progress.h
@@ -47,7 +47,7 @@ class Progress : public QDialog, public Ui::Process
 {
 Q_OBJECT
 public:
-    explicit Progress(int action, QString path = "", QWidget * parent = 0, Qt::WindowFlags f = 0);
+    explicit Progress(int action, QString path = "", QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
 signals:
 

--- a/src/q4wine-gui/run.h
+++ b/src/q4wine-gui/run.h
@@ -54,7 +54,7 @@ class Run : public QDialog, public Ui::Run
          *
          * \param  prefix_name  Current user selected prefix name.
          */
-        Run(QWidget * parent = 0, Qt::WindowFlags f = 0);
+        Run(QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
         void prepare(QString prefix_name, QString wrkdir="", QString override="", QString winedebug="", QString useconsole="", QString display="", QString cmdargs="", QString desktop="", int nice = 0, QString exec = "", QString lang = "");
         ExecObject execObj;
     private slots:

--- a/src/q4wine-gui/versions.h
+++ b/src/q4wine-gui/versions.h
@@ -45,7 +45,7 @@ class VersionManager : public QDialog, public Ui::VersionManager
 {
     Q_OBJECT
 public:
-    VersionManager(QWidget * parent = 0, Qt::WindowFlags f = 0);
+    VersionManager(QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     ~VersionManager();
     void setVersionFocus(QString version);
 signals:

--- a/src/q4wine-gui/widgets/appdb/appdbheaderwidget.h
+++ b/src/q4wine-gui/widgets/appdb/appdbheaderwidget.h
@@ -44,7 +44,7 @@ class AppDBHeaderWidget : public QFrame
 {
     Q_OBJECT
 public:
-    explicit AppDBHeaderWidget(QWidget * parent = 0);
+    explicit AppDBHeaderWidget(QWidget * parent = nullptr);
     void addLabel(QString info);
     void addLink(QString text, bool enabled = true, short int action = 0, QString search = "", int value = 0);
     void setLayout(short int direction);

--- a/src/q4wine-gui/widgets/appdb/appdbscrollwidget.h
+++ b/src/q4wine-gui/widgets/appdb/appdbscrollwidget.h
@@ -40,7 +40,7 @@ class AppDBScrollWidget : public QScrollArea
 {
 	Q_OBJECT
 public:
-    explicit AppDBScrollWidget(QWidget * parent = 0);
+    explicit AppDBScrollWidget(QWidget * parent = nullptr);
 	void addSearchWidget(const WineAppDBInfo appinfo);
 	void addTestWidget(const WineAppDBInfo appinfo);
 	void addVersionFrame(QList<WineAppDBCategory> list, QString frame_caption, short int action);

--- a/src/q4wine-gui/widgets/appdb/appdbwidget.h
+++ b/src/q4wine-gui/widgets/appdb/appdbwidget.h
@@ -48,7 +48,7 @@ class AppDBWidget : public QWidget
 {
 Q_OBJECT
 public:
-	explicit AppDBWidget(QWidget *parent = 0);
+	explicit AppDBWidget(QWidget *parent = nullptr);
 
 public slots:
 	void itemTrigged(short int action, QString search="", int val1=0, int val2=0, int val3=0);

--- a/src/q4wine-gui/widgets/appdb/appinfowidget.h
+++ b/src/q4wine-gui/widgets/appdb/appinfowidget.h
@@ -59,7 +59,7 @@ public:
     * \param  url	       Application url to open.
     */
 
-    AppInfoWidget(QString name, QString desc, const int appid, QList<WineAppDBVersionInfo> versions, QWidget *parent = 0);
+    AppInfoWidget(QString name, QString desc, const int appid, QList<WineAppDBVersionInfo> versions, QWidget *parent = nullptr);
 
     //! \brief class destructor;
     ~AppInfoWidget();

--- a/src/q4wine-gui/widgets/appdb/apptestwidget.h
+++ b/src/q4wine-gui/widgets/appdb/apptestwidget.h
@@ -41,7 +41,7 @@ class AppTestWidget : public QWidget, public Ui::AppTestWidget
 {
 Q_OBJECT
 public:
-	AppTestWidget(const WineAppDBInfo appinfo, QWidget *parent = 0);
+	AppTestWidget(const WineAppDBInfo appinfo, QWidget *parent = nullptr);
 
 public slots:
 	void requestParentComment(int id);

--- a/src/q4wine-gui/widgets/appdb/commentwidget.h
+++ b/src/q4wine-gui/widgets/appdb/commentwidget.h
@@ -43,7 +43,7 @@ class CommentWidget : public QFrame, public Ui::CommentWidget
 {
 	Q_OBJECT
 public:
-	CommentWidget(const WineAppDBComment comment, QWidget * parent = 0);
+	CommentWidget(const WineAppDBComment comment, QWidget * parent = nullptr);
 	void setId(int id);
 	void setParentId(int id);
 	bool isId(int id);

--- a/src/q4wine-gui/widgets/appdb/lineitemwidget.h
+++ b/src/q4wine-gui/widgets/appdb/lineitemwidget.h
@@ -50,7 +50,7 @@ class LineItemWidget : public QWidget
 Q_OBJECT
 public:
 	//! Class constructor
-	LineItemWidget(const short int action, QWidget *parent = 0);
+	LineItemWidget(const short int action, QWidget *parent = nullptr);
 
 	//! Class destructor
 	~LineItemWidget();

--- a/src/q4wine-gui/widgets/appdb/linkitemwidget.h
+++ b/src/q4wine-gui/widgets/appdb/linkitemwidget.h
@@ -30,7 +30,7 @@ class LinkItemWidget : public QLabel
 {
 	Q_OBJECT
 public:
-	LinkItemWidget(QString text, short int action = 0, QWidget *parent = 0);
+	LinkItemWidget(QString text, short int action = 0, QWidget *parent = nullptr);
 	~LinkItemWidget();
 
 	void setEnabled(bool enable);

--- a/src/q4wine-gui/widgets/drivelistwidgetitem.h
+++ b/src/q4wine-gui/widgets/drivelistwidgetitem.h
@@ -32,7 +32,7 @@ class DriveListWidgetItem : public QObject, public QListWidgetItem
 {
 Q_OBJECT
 public:
-	DriveListWidgetItem(QListWidget * parent = 0, int type = QListWidgetItem::UserType);
+	DriveListWidgetItem(QListWidget * parent = nullptr, int type = QListWidgetItem::UserType);
 
 	void setDrive(QString letter, QString path, QString type);
 	QString getLetter();

--- a/src/q4wine-gui/widgets/iconlisttoolbar.h
+++ b/src/q4wine-gui/widgets/iconlisttoolbar.h
@@ -37,7 +37,7 @@ class IconListToolbar : public QWidget
 {
 Q_OBJECT
 public:
-    explicit IconListToolbar(QWidget *parent = 0);
+    explicit IconListToolbar(QWidget *parent = nullptr);
 
 signals:
     void searchFilterChange(QString filter);

--- a/src/q4wine-gui/widgets/iconlistwidget.h
+++ b/src/q4wine-gui/widgets/iconlistwidget.h
@@ -64,7 +64,7 @@ class IconListWidget : public QListWidget
 {
       Q_OBJECT
 public:
-      explicit IconListWidget(QWidget *parent = 0);
+      explicit IconListWidget(QWidget *parent = nullptr);
       ~IconListWidget();
 
 public slots:

--- a/src/q4wine-gui/widgets/loggingwidget.h
+++ b/src/q4wine-gui/widgets/loggingwidget.h
@@ -55,7 +55,7 @@ class LoggingWidget : public QWidget
 {
 Q_OBJECT
 public:
-    explicit LoggingWidget(QWidget *parent = 0);
+    explicit LoggingWidget(QWidget *parent = nullptr);
     ~LoggingWidget();
 
 

--- a/src/q4wine-gui/widgets/prefixconfigwidget.h
+++ b/src/q4wine-gui/widgets/prefixconfigwidget.h
@@ -55,7 +55,7 @@ class PrefixConfigWidget : public QWidget
 {
 Q_OBJECT
 public:
-    explicit PrefixConfigWidget(QWidget *parent = 0);
+    explicit PrefixConfigWidget(QWidget *parent = nullptr);
     ~PrefixConfigWidget();
 
 

--- a/src/q4wine-gui/widgets/prefixcontrolwidget.h
+++ b/src/q4wine-gui/widgets/prefixcontrolwidget.h
@@ -57,7 +57,7 @@ class PrefixControlWidget : public QWidget
 {
 Q_OBJECT
 public:
-	explicit PrefixControlWidget(QWidget *parent = 0);
+	explicit PrefixControlWidget(QWidget *parent = nullptr);
 
 signals:
 

--- a/src/q4wine-gui/widgets/prefixtreetoolbar.h
+++ b/src/q4wine-gui/widgets/prefixtreetoolbar.h
@@ -42,7 +42,7 @@ class PrefixTreeToolbar : public QWidget
 {
 Q_OBJECT
 public:
-    explicit PrefixTreeToolbar(QWidget *parent = 0);
+    explicit PrefixTreeToolbar(QWidget *parent = nullptr);
     ~PrefixTreeToolbar();
 
 signals:

--- a/src/q4wine-gui/widgets/prefixtreewidget.h
+++ b/src/q4wine-gui/widgets/prefixtreewidget.h
@@ -58,7 +58,7 @@ class PrefixTreeWidget : public QTreeWidget
 {
 Q_OBJECT
 public:
-      explicit PrefixTreeWidget(QWidget *parent = 0);
+      explicit PrefixTreeWidget(QWidget *parent = nullptr);
       ~PrefixTreeWidget();
 
 private:

--- a/src/q4wine-gui/widgets/wineprocesswidget.h
+++ b/src/q4wine-gui/widgets/wineprocesswidget.h
@@ -49,7 +49,7 @@ class WineProcessWidget : public QWidget
 {
 Q_OBJECT
 public:
-	explicit WineProcessWidget(QWidget *parent = 0);
+	explicit WineProcessWidget(QWidget *parent = nullptr);
 
 signals:
 	void changeStatusText(QString);

--- a/src/q4wine-gui/winedrivedialog.h
+++ b/src/q4wine-gui/winedrivedialog.h
@@ -45,8 +45,8 @@ public:
 	 * \param  WizardType	Type of wizard scenario.
 	 * \param  var1			This variable used for different scenario actions.
 	 */
-	WineDriveDialog(QStringList removeLetters, QWidget * parent = 0, Qt::WindowFlags f = 0);
-	WineDriveDialog(QStringList removeLetters, QString driveLetter, QString drivePath, QString driveType, QWidget * parent = 0, Qt::WindowFlags f = 0);
+	WineDriveDialog(QStringList removeLetters, QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+	WineDriveDialog(QStringList removeLetters, QString driveLetter, QString drivePath, QString driveType, QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
 	QString getLetter();
 	QString getPath();

--- a/src/q4wine-gui/wizard.h
+++ b/src/q4wine-gui/wizard.h
@@ -60,7 +60,7 @@ class Wizard : public QDialog, public Ui::Wizard
          * \param  WizardType	Type of wizard scenario.
          * \param  var1			This variable used for different scenario actions.
          */
-        Wizard(int WizardType, QString var1 = "", QWidget * parent = 0, Qt::WindowFlags f = 0);
+        Wizard(int WizardType, QString var1 = "", QWidget * parent = nullptr, Qt::WindowFlags f =  Qt::WindowFlags());
         QString getPrefixName();
 
     private slots:

--- a/src/q4wine-helper/q4wine-helper.cpp
+++ b/src/q4wine-helper/q4wine-helper.cpp
@@ -45,13 +45,13 @@ int main(int argc, char *argv[])
     CoreLib.reset(static_cast<corelib *>(CoreLibClassPointer(false)));
 
     if (!CoreLib.get()){
-        QErr<<"[EE] Cannot load shared library."<<endl;
+        QErr<<"[EE] Cannot load shared library."<<Qt::endl;
         return -1;
     }
 
     DataBase db;
     if (!db.checkDb()){
-        QErr<<"[EE] Cannot initialize database engine."<<endl;
+        QErr<<"[EE] Cannot initialize database engine."<<Qt::endl;
         return -1;
     }
 
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
     app.installTranslator(&qtt);
 
     if (!CoreLib->isConfigured()){
-       QErr<<"[EE] App is not configured! Rerun wizard, or delete Q4Wine broken config files."<<endl;
+       QErr<<"[EE] App is not configured! Rerun wizard, or delete Q4Wine broken config files."<<Qt::endl;
        return -1;
     }
 
@@ -86,13 +86,13 @@ int main(int argc, char *argv[])
     for (int i=1; i<argc; i++){
         qDebug()<<app.arguments().at(i);
         if ((app.arguments().at(1)=="--version") or (app.arguments().at(1)=="-v")){
-            Qcout<<QString("%1-helper %2").arg(APP_SHORT_NAME).arg(APP_VERS)<<endl;
-            Qcout<<QString("Copyright (C) 2008-2021 by Oleksii S. Malakhov <brezerk@gmail.com>")<<endl;
-            Qcout<<QString("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.")<<endl;
-            Qcout<<QObject::tr("This is free software: you are free to change and redistribute it.")<<endl;
-            Qcout<<QObject::tr("There is NO WARRANTY, to the extent permitted by law.")<<endl;
+            Qcout<<QString("%1-helper %2").arg(APP_SHORT_NAME).arg(APP_VERS)<<Qt::endl;
+            Qcout<<QString("Copyright (C) 2008-2021 by Oleksii S. Malakhov <brezerk@gmail.com>")<<Qt::endl;
+            Qcout<<QString("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.")<<Qt::endl;
+            Qcout<<QObject::tr("This is free software: you are free to change and redistribute it.")<<Qt::endl;
+            Qcout<<QObject::tr("There is NO WARRANTY, to the extent permitted by law.")<<Qt::endl;
             CoreLib->getBuildFlags();
-            Qcout<<QObject::tr("Author: %1.").arg("Oleksii S. Malakhov")<<endl;
+            Qcout<<QObject::tr("Author: %1.").arg("Oleksii S. Malakhov")<<Qt::endl;
             return 0;
         } else if (app.arguments().at(i)=="--prefix"){
             i++;
@@ -147,27 +147,27 @@ int main(int argc, char *argv[])
             if (i<argc)
                 wineObject.setPostRun(app.arguments().at(i));
         } else {
-            Qcout<<QObject::tr("Usage:")<<endl;
-            Qcout<<QObject::tr("  %1-helper [KEYs]...").arg(APP_SHORT_NAME)<<endl;
-            Qcout<<QObject::tr("Console utility for Q4Wine which helps to handle Wine application exit status and its stdout/stderr output logging.")<<endl<<endl;
-            Qcout<<QObject::tr("KEYs list:")<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --prefix"<<QObject::tr("sets the current prefix name")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --wine-debug"<<QObject::tr("sets WINEDEBUG variable")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --console"<<QObject::tr("run with output in console")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --display"<<QObject::tr("sets DISPLAY variable")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --nice"<<QObject::tr("sets program niceness")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --desktop"<<QObject::tr("sets program virtual desktop resolution")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --program-bin"<<QObject::tr("sets program binary")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --program-args"<<QObject::tr("sets program args")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --wrkdir"<<QObject::tr("sets program working directory")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --program-lang"<<QObject::tr("sets program LANG variable")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --override"<<QObject::tr("sets WINEDLLOVERRIDES variable")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --prerun"<<QObject::tr("execute script before program run")<<qSetFieldWidth(0)<<endl;
-            Qcout<<qSetFieldWidth(25)<<left<<"  --postrun"<<QObject::tr("execute script after program run")<<qSetFieldWidth(0)<<endl;
-            Qcout<<endl;
-            Qcout<<QObject::tr("Report %1 bugs to %2").arg(APP_SHORT_NAME).arg(APP_BUG_EMAIL)<<endl;
-            Qcout<<QObject::tr("%1 homepage: <%2>").arg(APP_SHORT_NAME).arg(APP_WEBSITE)<<endl;
-            Qcout<<QObject::tr("General help using GNU software: <http://www.gnu.org/gethelp/>")<<endl;
+            Qcout<<QObject::tr("Usage:")<<Qt::endl;
+            Qcout<<QObject::tr("  %1-helper [KEYs]...").arg(APP_SHORT_NAME)<<Qt::endl;
+            Qcout<<QObject::tr("Console utility for Q4Wine which helps to handle Wine application exit status and its stdout/stderr output logging.")<<Qt::endl<<Qt::endl;
+            Qcout<<QObject::tr("KEYs list:")<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --prefix"<<QObject::tr("sets the current prefix name")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --wine-debug"<<QObject::tr("sets WINEDEBUG variable")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --console"<<QObject::tr("run with output in console")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --display"<<QObject::tr("sets DISPLAY variable")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --nice"<<QObject::tr("sets program niceness")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --desktop"<<QObject::tr("sets program virtual desktop resolution")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --program-bin"<<QObject::tr("sets program binary")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --program-args"<<QObject::tr("sets program args")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --wrkdir"<<QObject::tr("sets program working directory")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --program-lang"<<QObject::tr("sets program LANG variable")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --override"<<QObject::tr("sets WINEDLLOVERRIDES variable")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --prerun"<<QObject::tr("execute script before program run")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<qSetFieldWidth(25)<<Qt::left<<"  --postrun"<<QObject::tr("execute script after program run")<<qSetFieldWidth(0)<<Qt::endl;
+            Qcout<<Qt::endl;
+            Qcout<<QObject::tr("Report %1 bugs to %2").arg(APP_SHORT_NAME).arg(APP_BUG_EMAIL)<<Qt::endl;
+            Qcout<<QObject::tr("%1 homepage: <%2>").arg(APP_SHORT_NAME).arg(APP_WEBSITE)<<Qt::endl;
+            Qcout<<QObject::tr("General help using GNU software: <http://www.gnu.org/gethelp/>")<<Qt::endl;
             return 0;
         }
     }

--- a/src/q4wine-helper/wineobject.h
+++ b/src/q4wine-helper/wineobject.h
@@ -50,7 +50,7 @@ class WineObject : public QObject
 {
     Q_OBJECT
 public:
-    explicit WineObject(QObject *parent = 0);
+    explicit WineObject(QObject *parent = nullptr);
 
     bool setPrefix(const QString &prefix);
 

--- a/src/q4wine-lib/q4wine-lib.cpp
+++ b/src/q4wine-lib/q4wine-lib.cpp
@@ -571,39 +571,39 @@ bool corelib::checkDirs(const QString &rootPath, QStringList subDirs) const{
 
 void corelib::getBuildFlags(){
     QTextStream Qcout(stdout);
-    Qcout<<QObject::tr("Buildtime flags are:")<<endl<<endl;
-    Qcout<<qSetFieldWidth(25)<<left<<" CMAKE_INSTALL_PREFIX"<<QString::fromUtf8(APP_PREF)<<qSetFieldWidth(0)<<endl<<endl;
+    Qcout<<QObject::tr("Buildtime flags are:")<<Qt::endl<<Qt::endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" CMAKE_INSTALL_PREFIX"<<QString::fromUtf8(APP_PREF)<<qSetFieldWidth(0)<<Qt::endl<<Qt::endl;
 #ifdef RELEASE
-    Qcout<<qSetFieldWidth(25)<<left<<" RELEASE"<<"ON"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" RELEASE"<<"ON"<<qSetFieldWidth(0)<<Qt::endl;
 #else
-    Qcout<<qSetFieldWidth(25)<<left<<" RELEASE"<<"OFF"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" RELEASE"<<"OFF"<<qSetFieldWidth(0)<<Qt::endl;
 #endif
 #ifdef DEBUG
-    Qcout<<qSetFieldWidth(25)<<left<<" DEBUG"<<"ON"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" DEBUG"<<"ON"<<qSetFieldWidth(0)<<Qt::endl;
 #else
-    Qcout<<qSetFieldWidth(25)<<left<<" DEBUG"<<"OFF"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" DEBUG"<<"OFF"<<qSetFieldWidth(0)<<Qt::endl;
 #endif
 #ifdef WITH_ICOUTILS
-    Qcout<<qSetFieldWidth(25)<<left<<" WITH_ICOUTILS"<<"ON"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" WITH_ICOUTILS"<<"ON"<<qSetFieldWidth(0)<<Qt::endl;
 #else
-    Qcout<<qSetFieldWidth(25)<<left<<" WITH_ICOUTILS"<<"OFF"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" WITH_ICOUTILS"<<"OFF"<<qSetFieldWidth(0)<<Qt::endl;
 #endif
 #ifdef WITH_SYSTEM_SINGLEAPP
-    Qcout<<qSetFieldWidth(25)<<left<<" WITH_SYSTEM_SINGLEAPP"<<"ON"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" WITH_SYSTEM_SINGLEAPP"<<"ON"<<qSetFieldWidth(0)<<Qt::endl;
 #else
-    Qcout<<qSetFieldWidth(25)<<left<<" WITH_SYSTEM_SINGLEAPP"<<"OFF"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" WITH_SYSTEM_SINGLEAPP"<<"OFF"<<qSetFieldWidth(0)<<Qt::endl;
 #endif
 #ifdef WITH_WINEAPPDB
-    Qcout<<qSetFieldWidth(25)<<left<<" WITH_WINEAPPDB "<<"ON"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" WITH_WINEAPPDB "<<"ON"<<qSetFieldWidth(0)<<Qt::endl;
 #else
-    Qcout<<qSetFieldWidth(25)<<left<<" WITH_WINEAPPDB "<<"OFF"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" WITH_WINEAPPDB "<<"OFF"<<qSetFieldWidth(0)<<Qt::endl;
 #endif
 #ifdef WITH_DBUS
-    Qcout<<qSetFieldWidth(25)<<left<<" WITH_DBUS"<<"ON"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" WITH_DBUS"<<"ON"<<qSetFieldWidth(0)<<Qt::endl;
 #else
-    Qcout<<qSetFieldWidth(25)<<left<<" WITH_DBUS"<<"OFF"<<qSetFieldWidth(0)<<endl;
+    Qcout<<qSetFieldWidth(25)<<Qt::left<<" WITH_DBUS"<<"OFF"<<qSetFieldWidth(0)<<Qt::endl;
 #endif
-    Qcout<<endl;
+    Qcout<<Qt::endl;
 }
 
 QString corelib::getWhichOut(const QString &fileName, bool showErr){
@@ -981,7 +981,7 @@ bool corelib::checkFileExists(const QString &path){
     if (path.mid(0,1)=="/"){
         if (!QFile(path).exists()){
             if (m_GUI_MODE){
-                QMessageBox::warning(0, QObject::tr("Error"), QObject::tr("Binary file \"%1\" does not exist.").arg(path));
+                QMessageBox::warning(nullptr, QObject::tr("Error"), QObject::tr("Binary file \"%1\" does not exist.").arg(path));
             } else {
                 qDebug()<<"[EE] Binary \""<<path<<"\" do not exists. Abort.";
             }
@@ -1029,7 +1029,7 @@ bool corelib::runWineBinary(const ExecObject &execObj, const QString &prefix_nam
     args.append("--prefix");
     args.append(prefix_name);
 
-    if (execObj.nice>0){
+    if (execObj.nice.isEmpty()){
         args.append("--nice");
         args.append(execObj.nice);
     }
@@ -1097,7 +1097,7 @@ bool corelib::runWineBinary(const ExecObject &execObj, const QString &prefix_nam
 #endif
 
     if (detach){
-        QProcess proc(0);
+        QProcess proc(nullptr);
         return proc.startDetached(binary, args, QDir::currentPath());
     } else {
         Process proc(args, binary, QDir::currentPath(), QObject::tr("Running binary: \"%1\"").arg(execObj.execcmd), QObject::tr("Running binary..."), false);
@@ -1142,61 +1142,61 @@ QString corelib::createDesktopFile(const QString &prefix_name, const QString &di
         return "";
 
     QTextStream out(&file);
-    out<<"[Desktop Entry]"<<endl;
+    out<<"[Desktop Entry]"<<Qt::endl;
     out<<"Exec="<<QString::fromUtf8(APP_PREF)<<"/bin/q4wine-cli -p \""<<prefix_name<<"\" ";
     if (!dir_name.isEmpty())
         out<<" -d \""<<dir_name<<"\" ";
-    out<<" -i \""<<icon_name<<"\" "<<" %f"<<endl;
+    out<<" -i \""<<icon_name<<"\" "<<" %f"<<Qt::endl;
 
     QString icon_path = result.value("icon_path");
 
     if (icon_path.isEmpty()){
-        out<<"Icon=application-x-ms-dos-executable"<<endl;
+        out<<"Icon=application-x-ms-dos-executable"<<Qt::endl;
     } else {
         if (QFile(icon_path).exists()){
-            out<<"Icon="<<icon_path<<endl;
+            out<<"Icon="<<icon_path<<Qt::endl;
         } else {
             if (icon_name == "eject"){
-                out<<"Icon="<<embedded_icon_path<<"cdrom"<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<"cdrom"<<".svg"<<Qt::endl;
             } else if (icon_name == "explorer"){
-                out<<"Icon="<<embedded_icon_path<<"winefile"<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<"winefile"<<".svg"<<Qt::endl;
             } else if (icon_name == "winecfg"){
-                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<Qt::endl;
             } else if (icon_name == "iexplore"){
-                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<Qt::endl;
             } else if (icon_name == "oleview"){
-                out<<"Icon="<<embedded_icon_path<<"oic_winlogo"<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<"oic_winlogo"<<".svg"<<Qt::endl;
             } else if (icon_name == "taskmgr"){
-                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<Qt::endl;
             } else if (icon_name == "control"){
-                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<Qt::endl;
             } else if (icon_name == "notepad"){
-                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<Qt::endl;
             } else if (icon_name == "regedit"){
-                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<Qt::endl;
             } else if (icon_name == "uninstaller"){
-                out<<"Icon="<<embedded_icon_path<<"trash_file"<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<"trash_file"<<".svg"<<Qt::endl;
             } else if (icon_name == "winemine"){
-                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<Qt::endl;
             } else if (icon_name == "wordpad"){
-                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<icon_name<<".svg"<<Qt::endl;
             } else if (icon_name == "wineconsole"){
-                out<<"Icon="<<embedded_icon_path<<"wcmd"<<".svg"<<endl;
+                out<<"Icon="<<embedded_icon_path<<"wcmd"<<".svg"<<Qt::endl;
             } else {
-                out<<"Icon=application-x-ms-dos-executable"<<endl;
+                out<<"Icon=application-x-ms-dos-executable"<<Qt::endl;
             }
         }
     }
-    out<<"Type=Application"<<endl;
-    out<<"StartupNotify=true"<<endl;
-    out<<"GenericName="<<icon_name<<endl;
+    out<<"Type=Application"<<Qt::endl;
+    out<<"StartupNotify=true"<<Qt::endl;
+    out<<"GenericName="<<icon_name<<Qt::endl;
     QString desc = result.value("desc");
     if (!desc.isEmpty()) {
-        out<<"Comment="<<desc<<endl;
+        out<<"Comment="<<desc<<Qt::endl;
     }
-    out<<"Name="<<icon_name<<endl;
-    out<<"Path="<<result.value("wrkdir")<<endl;
-    out<<"StartupWMClass="<<result.value("exec").split('/').last().split('\\').last()<<endl;
+    out<<"Name="<<icon_name<<Qt::endl;
+    out<<"Path="<<result.value("wrkdir")<<Qt::endl;
+    out<<"StartupWMClass="<<result.value("exec").split('/').last().split('\\').last()<<Qt::endl;
 
     file.close();
 
@@ -1510,7 +1510,7 @@ int corelib::showError(const QString &message, const bool info) const{
         }
     } else {
         QTextStream stdErr(stderr);
-        stdErr<<"[ee] "<<message<<endl; // message.toLatin1();
+        stdErr<<"[ee] "<<message<<Qt::endl; // message.toLatin1();
     }
     return 0;
 }
@@ -1520,7 +1520,7 @@ void corelib::showError(const QString &message) const{
     if (m_GUI_MODE){
         QMessageBox::warning(0, QObject::tr("Error"), message);
     } else {
-        Qcout<<QObject::tr("Error")<<endl<<message<<endl;
+        Qcout<<QObject::tr("Error")<<Qt::endl<<message<<Qt::endl;
     }
     return;
 }

--- a/src/q4wine-lib/q4wine-lib.cpp
+++ b/src/q4wine-lib/q4wine-lib.cpp
@@ -1029,7 +1029,7 @@ bool corelib::runWineBinary(const ExecObject &execObj, const QString &prefix_nam
     args.append("--prefix");
     args.append(prefix_name);
 
-    if (execObj.nice.isEmpty()){
+    if (!execObj.nice.isEmpty()){
         args.append("--nice");
         args.append(execObj.nice);
     }

--- a/src/qtsingleapplication/qtlocalpeer.h
+++ b/src/qtsingleapplication/qtlocalpeer.h
@@ -53,7 +53,7 @@ class QtLocalPeer : public QObject
     Q_OBJECT
 
 public:
-    QtLocalPeer(QObject *parent = 0, const QString &appId = QString());
+    QtLocalPeer(QObject *parent = nullptr, const QString &appId = QString());
     bool isClient();
     bool sendMessage(const QString &message, int timeout);
     QString applicationId() const


### PR DESCRIPTION
I have made following changes:
 - `endl` -> `Qt::endl`
 - `left` -> `Qt::left`
 
This will remove almost every warning from compiler.